### PR TITLE
Add endpoints for password reset functionality

### DIFF
--- a/lib/malan/accounts/session.ex
+++ b/lib/malan/accounts/session.ex
@@ -59,7 +59,7 @@ defmodule Malan.Accounts.Session do
     api_token = gen_api_token()
     changeset
     |> put_change(:api_token, api_token)
-    |> put_change(:api_token_hash, Utils.Crypto.hash_api_token(api_token))
+    |> put_change(:api_token_hash, Utils.Crypto.hash_token(api_token))
   end
 
   defp put_authenticated_at(changeset) do

--- a/lib/malan/utils.ex
+++ b/lib/malan/utils.ex
@@ -20,6 +20,17 @@ defmodule Malan.Utils do
     Map.from_struct(struct)
     |> Map.delete(:__meta__)
   end
+
+  #def nil_or_empty?(nil), do: true
+  #def nil_or_empty?(str) when is_string(str), do: "" == str |> String.trim()
+
+  @doc """
+  Checks if the passwed item is nil or empty string.  The param will be passed to to_string()
+  and then trimmed and checked for empty string
+  """
+  def nil_or_empty?(str_or_nil) do
+    "" == str_or_nil |> to_string() |> String.trim()
+  end
 end
 
 defmodule Malan.Utils.Enum do
@@ -55,7 +66,7 @@ defmodule Malan.Utils.Crypto do
     Pbkdf2.no_user_verify()
   end
 
-  def hash_api_token(api_token) do
+  def hash_token(api_token) do
     :crypto.hash(:sha256, api_token)
     |> Base.encode64()
   end

--- a/lib/malan_web/router.ex
+++ b/lib/malan_web/router.ex
@@ -112,6 +112,7 @@ defmodule MalanWeb.Router do
     #end
   end
 
+  #scope "/api/admin", MalanWeb, as: :admin do
   scope "/api/admin", MalanWeb do
     pipe_through :admin_api
 
@@ -120,5 +121,12 @@ defmodule MalanWeb.Router do
 
     get "/sessions", SessionController, :admin_index
     delete "/sessions/:id", SessionController, :admin_delete
+
+    # These password reset endpoints are currently restricted to admins,
+    # but once Malan can send the reset token via email and also serve the landing
+    # page, these can be moved to unauthenticated so that users can reset their
+    # own passwords
+    post "/users/:id/reset_password", UserController, :admin_reset_password
+    put "/users/:id/reset_password/:token", UserController, :admin_reset_password_token
   end
 end

--- a/lib/malan_web/views/user_view.ex
+++ b/lib/malan_web/views/user_view.ex
@@ -58,4 +58,10 @@ defmodule MalanWeb.UserView do
       }
     }
   end
+
+  def render("password_reset.json", %{password_reset_token: password_reset_token}) do
+    %{data:
+      %{password_reset_token: password_reset_token}
+    }
+  end
 end

--- a/priv/repo/migrations/20210802210324_add_password_reset_token_column.exs
+++ b/priv/repo/migrations/20210802210324_add_password_reset_token_column.exs
@@ -1,0 +1,9 @@
+defmodule Malan.Repo.Migrations.AddPasswordResetTokenColumn do
+  use Ecto.Migration
+
+  def change do
+    alter table("users") do
+      add :password_reset_token_hash, :string, null: true, default: nil
+    end
+  end
+end

--- a/test/malan/utils_test.exs
+++ b/test/malan/utils_test.exs
@@ -3,6 +3,15 @@ defmodule Malan.UtilsTest do
 
   use ExUnit.Case, async: true
 
+  describe "main" do
+    test "nil_or_empty?/1" do
+      assert true == Utils.nil_or_empty?(nil)
+      assert true == Utils.nil_or_empty?("")
+      assert false == Utils.nil_or_empty?("abcd")
+      assert false == Utils.nil_or_empty?(42)
+    end
+  end
+
   describe "Crypto" do
     test "#strong_random_string" do
       str = Utils.Crypto.strong_random_string(12)


### PR DESCRIPTION
New endpoints:

POST /users/:id/reset_password        --- Returns {"password_reset_token": "abc"}
PUT  /users/:id/reset_password/:token --- { "new_password": "<whatever>" }

Currently because the password reset token is returned in-band, only an
authenticated administrator user is allowed to call these endpoints.

Fixes #18