### PR TITLE
Add expiration to password reset tokens

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -11,6 +11,9 @@ config :malan,
   ecto_repos: [Malan.Repo],
   generators: [binary_id: true]
 
+config :malan, Malan.Accounts.User,
+  default_password_reset_token_expiration_secs: System.get_env("DEFAULT_PASSWORD_RESET_TOKEN_EXPIRATION_SECS") || "86400" |> String.to_integer() # 24 hours
+
 config :malan, Malan.Accounts.Session,
   default_token_expiration_secs: System.get_env("DEFAULT_TOKEN_EXPIRATION_SECS") || "604800" |> String.to_integer() # One week
 

--- a/lib/malan/accounts.ex
+++ b/lib/malan/accounts.ex
@@ -127,13 +127,15 @@ defmodule Malan.Accounts do
   @doc """
   Checks if the provided password reset token in valid.  If it is, returns {:ok}.
 
-  If not returns {:error, :missing_password_reset_token} if the user does not have a valid reset token issued or {:error, :invalid_password_reset_token} if the password reset token is incorrect
+  If not returns {:error, :missing_password_reset_token} if the user does not have a valid reset token issued or {:error, :invalid_password_reset_token} if the password reset token is incorrect.
+
+  Returns {:error, :expired_password_reset_token} if token is expired
   """
   def validate_password_reset_token(user, password_reset_token) do
     cond do
       Utils.nil_or_empty?(user.password_reset_token_hash) -> {:error, :missing_password_reset_token}
+      Utils.DateTime.expired?(user.password_reset_token_expires_at) -> {:error, :expired_password_reset_token}
       user.password_reset_token_hash == Utils.Crypto.hash_token(password_reset_token) -> {:ok}
-      # TODO:  Add clause to check for expiration
       true -> {:error, :invalid_password_reset_token}
     end
   end

--- a/lib/malan/accounts/user.ex
+++ b/lib/malan/accounts/user.ex
@@ -34,6 +34,7 @@ defmodule Malan.Accounts.User do
     field :custom_attrs, :map              # Free form JSON for dependent services to use
     field :password_reset_token, :string, virtual: true
     field :password_reset_token_hash, :string
+    field :password_reset_token_expires_at, :utc_datetime
 
     embeds_one :preferences, Accounts.Preference, on_replace: :update
 
@@ -105,6 +106,7 @@ defmodule Malan.Accounts.User do
     user
     |> change()
     |> put_password_reset_token()
+    |> put_password_reset_token_expires_at()
   end
 
   @doc false
@@ -112,6 +114,7 @@ defmodule Malan.Accounts.User do
     user
     |> change()
     |> clear_password_reset_token()
+    |> clear_password_reset_token_expires_at()
   end
 
   @doc false
@@ -386,7 +389,20 @@ defmodule Malan.Accounts.User do
     changeset
     |> put_change(:password_reset_token, nil)
     |> put_change(:password_reset_token_hash, nil)
-    #|> put_change(:password_reset_token, "")
-    #|> put_change(:password_reset_token_hash, "")
+  end
+
+  defp put_password_reset_token_expires_at(changeset) do
+    changeset
+    |> put_change(:password_reset_token_expires_at, get_password_reset_token_expiration_time())
+  end
+
+  defp clear_password_reset_token_expires_at(changeset) do
+    changeset
+    |> put_change(:password_reset_token_expires_at, nil)
+  end
+
+  defp get_password_reset_token_expiration_time do
+    Application.get_env(:malan, Malan.Accounts.User)[:default_password_reset_token_expiration_secs]
+    |> Utils.DateTime.adjust_cur_time_trunc(:seconds)
   end
 end

--- a/lib/malan/utils.ex
+++ b/lib/malan/utils.ex
@@ -131,7 +131,16 @@ defmodule Malan.Utils.DateTime do
   def adjust_time(time, num_minutes, :minutes),
     do: adjust_time(time, num_minutes * 60, :seconds)
 
-  def adjust_time(time, num_seconds, :seconds), do:
-    DateTime.add(time, num_seconds, :second)
+  def adjust_time(time, num_seconds, :seconds),
+    do: DateTime.add(time, num_seconds, :second)
+
+  def expired?(expires_at, current_time),
+    do: DateTime.compare(expires_at, current_time) != :gt
+
+  def expired?(nil),
+    do: raise ArgumentError, message: "expires_at time must not be nil!"
+
+  def expired?(expires_at),
+    do: expired?(expires_at, DateTime.utc_now)
 
 end

--- a/lib/malan_web/controllers/user_controller.ex
+++ b/lib/malan_web/controllers/user_controller.ex
@@ -101,8 +101,12 @@ defmodule MalanWeb.UserController do
           conn
           |> put_status(401)
           |> json(%{ok: false, err: :invalid_password_reset_token, msg: "Password reset token in invalid"})
-        end
+        {:error, :expired_password_reset_token} ->
+          conn
+          |> put_status(401)
+          |> json(%{ok: false, err: :expired_password_reset_token, msg: "Password reset token is expired"})
       end
+    end
   end
 
   def whoami(conn, _params) do
@@ -143,7 +147,8 @@ defmodule MalanWeb.UserController do
     render(
       conn,
       "password_reset.json",
-      password_reset_token: user.password_reset_token
+      password_reset_token: user.password_reset_token,
+      password_reset_token_expires_at: user.password_reset_token_expires_at
     )
   end
 

--- a/lib/malan_web/views/user_view.ex
+++ b/lib/malan_web/views/user_view.ex
@@ -59,9 +59,12 @@ defmodule MalanWeb.UserView do
     }
   end
 
-  def render("password_reset.json", %{password_reset_token: password_reset_token}) do
+  def render("password_reset.json", %{password_reset_token: password_reset_token, password_reset_token_expires_at: password_reset_token_expires_at}) do
     %{data:
-      %{password_reset_token: password_reset_token}
+      %{
+        password_reset_token: password_reset_token,
+        password_reset_token_expires_at: password_reset_token_expires_at
+      }
     }
   end
 end

--- a/priv/repo/migrations/20210808201703_add_password_reset_token_expiration.exs
+++ b/priv/repo/migrations/20210808201703_add_password_reset_token_expiration.exs
@@ -1,0 +1,9 @@
+defmodule Malan.Repo.Migrations.AddPasswordResetTokenExpiration do
+  use Ecto.Migration
+
+  def change do
+    alter table(:users) do
+      add :password_reset_token_expires_at, :utc_datetime, null: true, default: nil
+    end
+  end
+end

--- a/test/malan/utils_test.exs
+++ b/test/malan/utils_test.exs
@@ -1,5 +1,6 @@
 defmodule Malan.UtilsTest do
   alias Malan.Utils
+  alias Malan.Test
 
   use ExUnit.Case, async: true
 
@@ -35,6 +36,20 @@ defmodule Malan.UtilsTest do
     # This exercises all of the adjust_time funcs since they call each other
       start_dt = DateTime.utc_now
       assert DateTime.add(start_dt, 2 * 7 * 24 * 60 * 60, :second) == Utils.DateTime.adjust_time(start_dt, 2, :weeks)
+    end
+
+    test "expired?" do
+      cur_time = DateTime.utc_now
+
+      assert_raise(ArgumentError, ~r/expires_at.*must.not.be.nil/, fn -> Utils.DateTime.expired?(nil) end)
+
+      assert false == Utils.DateTime.expired?(Utils.DateTime.adjust_cur_time( 1, :minutes))
+      assert true  == Utils.DateTime.expired?(Utils.DateTime.adjust_cur_time(-1, :minutes))
+      assert true  == Utils.DateTime.expired?(cur_time) # exact same time shows as expired
+
+      assert true  == Utils.DateTime.expired?(cur_time, Utils.DateTime.adjust_cur_time( 1, :minutes))
+      assert false == Utils.DateTime.expired?(cur_time, Utils.DateTime.adjust_cur_time(-1, :minutes))
+      assert true  == Utils.DateTime.expired?(cur_time, cur_time)
     end
   end
 


### PR DESCRIPTION
This way a password reset token is only usable during the time period
specified.

Fixes #19