### PR TITLE
Downcase username and emails at creation time

### DIFF
--- a/lib/malan/accounts/user.ex
+++ b/lib/malan/accounts/user.ex
@@ -72,6 +72,8 @@ defmodule Malan.Accounts.User do
     |> put_change(:roles, ["user"])
     |> put_change(:preferences, %{theme: "light"})
     |> cast_assoc(:phone_numbers, with: &Malan.Accounts.PhoneNumber.create_changeset_assoc/2)
+    |> downcase_username()
+    |> downcase_email()
     |> validate_common()
   end
 
@@ -94,6 +96,8 @@ defmodule Malan.Accounts.User do
     |> cast(params, [:email, :username, :password, :first_name, :last_name, :nick_name, :roles, :reset_password, :sex, :gender, :race, :ethnicity, :birthday, :weight, :height, :custom_attrs])
     |> cast_embed(:preferences)
     |> cast_assoc(:phone_numbers, with: &Malan.Accounts.PhoneNumber.create_changeset_assoc/2)
+    |> downcase_username()
+    |> downcase_email()
     |> put_reset_pass()
     |> validate_common()
   end
@@ -409,4 +413,16 @@ defmodule Malan.Accounts.User do
     Application.get_env(:malan, Malan.Accounts.User)[:default_password_reset_token_expiration_secs]
     |> Utils.DateTime.adjust_cur_time_trunc(:seconds)
   end
+
+  defp downcase_username(%Ecto.Changeset{changes: %{username: username}} = cs) do
+    put_change(cs, :username, String.downcase(username))
+  end
+
+  defp downcase_username(changeset), do: changeset
+
+  defp downcase_email(%Ecto.Changeset{changes: %{email: email}} = cs) do
+    put_change(cs, :email, String.downcase(email))
+  end
+
+  defp downcase_email(changeset), do: changeset
 end

--- a/test/malan/accounts_test.exs
+++ b/test/malan/accounts_test.exs
@@ -498,6 +498,38 @@ defmodule Malan.AccountsTest do
       assert %{ uf | custom_attrs: %{}, password: nil } == u2
       assert u1 == u2
     end
+
+    test "when creating users the username and email are lowercased" do
+      uf = user_fixture(%{username: "CaPitAlUsername", email: "CaPitALaddr@example.COM"})
+      assert uf.email == "capitaladdr@example.com"
+      assert uf.username == "capitalusername"
+      assert %User{
+        email: "capitaladdr@example.com",
+        username: "capitalusername"
+      } = Accounts.get_user(uf.id)
+    end
+
+    test "getting a user with capitals by username returns the correct" do
+      orig_email = "CaPitALaddr@example.COM"
+      orig_username = "CaPitAlUsername"
+      %User{id: user_id} = user_fixture(%{username: orig_username, email: orig_email})
+      assert %User{
+        id: ^user_id,
+        email: "capitaladdr@example.com",
+        username: "capitalusername"
+      } = Accounts.get_user_by_id_or_username(orig_username)
+    end
+
+    test "getting a user with capitals by email returns the correct" do
+      orig_email = "CaPitALaddr@example.COM"
+      orig_username = "CaPitAlUsername"
+      %User{id: user_id} = user_fixture(%{username: orig_username, email: orig_email})
+      assert %User{
+        id: ^user_id,
+        email: "capitaladdr@example.com",
+        username: "capitalusername"
+      } = Accounts.get_user_by(email: orig_email)
+    end
   end
 
   describe "sessions" do


### PR DESCRIPTION
They are stored as citext, but this is nice for consistency

Refs #27