### PR TITLE
Allow using username or ID for user endpoints

### DIFF
--- a/lib/malan_web/controllers/auth_controller.ex
+++ b/lib/malan_web/controllers/auth_controller.ex
@@ -79,7 +79,7 @@ defmodule Malan.AuthController do
   """
   def validate_token(conn, _opts) do
     with {:ok, api_token} <- retrieve_token(conn),
-         {:ok, user_id, session_id, user_roles, expires_at, tos, pp} <- Accounts.validate_session(api_token),
+         {:ok, user_id, username, session_id, user_roles, expires_at, tos, pp} <- Accounts.validate_session(api_token),
          {:ok, accepted_tos} <- accepted_latest_tos?(tos),
          {:ok, accepted_pp} <- accepted_latest_pp?(pp),
          {:ok, is_admin} <- Accounts.user_is_admin?(user_roles),
@@ -88,6 +88,7 @@ defmodule Malan.AuthController do
       conn
       |> assign(:auth_error, nil)
       |> assign(:authed_user_id, user_id)
+      |> assign(:authed_username, username)
       |> assign(:auth_expires_at, expires_at)
       |> assign(:authed_session_id, session_id)
       |> assign(:authed_user_roles, user_roles)
@@ -104,6 +105,7 @@ defmodule Malan.AuthController do
         conn
         |> assign(:auth_error, err)
         |> assign(:authed_user_id, nil)
+        |> assign(:authed_username, nil)
         |> assign(:auth_expires_at, nil)
         |> assign(:authed_session_id, nil)
         |> assign(:authed_user_roles, [])
@@ -130,7 +132,7 @@ defmodule Malan.AuthController do
   def is_moderator_or_admin?(conn), do: !!(is_moderator?(conn) || is_admin?(conn))
   def is_admin_or_moderator?(conn), do: is_moderator_or_admin?(conn)
   def is_owner?(conn), do: is_owner?(conn, conn.params["user_id"])
-  def is_owner?(conn, user_id), do: conn.assigns.authed_user_id == user_id
+  def is_owner?(conn, user_id), do: conn.assigns.authed_user_id == user_id || conn.assigns.authed_username == user_id
 
   def is_not_admin?(conn), do: !is_admin?(conn)
   def is_not_moderator?(conn), do: !is_moderator?(conn)

--- a/lib/malan_web/controllers/user_controller.ex
+++ b/lib/malan_web/controllers/user_controller.ex
@@ -28,17 +28,17 @@ defmodule MalanWeb.UserController do
   def current(conn, _params), do: show(conn, %{"id" => conn.assigns.authed_user_id})
 
   def show(conn, %{"id" => id, "abbr" => _}) do
-    user = Accounts.get_user(id)
+    user = Accounts.get_user_by_id_or_username(id)
     render_user(conn, user)
   end
 
   def show(conn, %{"id" => id}) do
-    user = Accounts.get_user_full(id)
+    user = Accounts.get_user_full_by_id_or_username(id)
     render_user(conn, user)
   end
 
   def update(conn, %{"id" => id, "user" => user_params}) do
-    user = Accounts.get_user_full(id)
+    user = Accounts.get_user_full_by_id_or_username(id)
 
     if is_nil(user) do
       render_user(conn, user)
@@ -50,7 +50,7 @@ defmodule MalanWeb.UserController do
   end
 
   def admin_update(conn, %{"id" => id, "user" => user_params}) do
-    user = Accounts.get_user_full(id)
+    user = Accounts.get_user_full_by_id_or_username(id)
 
     if is_nil(user) do
       render_user(conn, user)
@@ -62,7 +62,7 @@ defmodule MalanWeb.UserController do
   end
 
   def delete(conn, %{"id" => id}) do
-    user = Accounts.get_user!(id)
+    user = Accounts.get_user_by_id_or_username!(id)
 
     if is_nil(user) do
       render_user(conn, user)
@@ -87,7 +87,7 @@ defmodule MalanWeb.UserController do
 
   def whoami(conn, _params) do
     case conn_to_session_info(conn) do
-      {:ok, user_id, session_id, user_roles, expires_at, tos, pp} -> render_whoami(conn, user_id, session_id, user_roles, expires_at, tos, pp)
+      {:ok, user_id, username, session_id, user_roles, expires_at, tos, pp} -> render_whoami(conn, user_id, session_id, user_roles, expires_at, tos, pp)
       # {:error, :revoked}
       # {:error, :expired}
       # {:error, :not_found}
@@ -96,7 +96,7 @@ defmodule MalanWeb.UserController do
   end
 
   def admin_reset_password_token_user(conn, %{"id" => id, "token" => token, "new_password" => new_password}), do:
-    admin_reset_password_token_p(conn, Accounts.get_user(id), token, new_password)
+    admin_reset_password_token_p(conn, Accounts.get_user_by_id_or_username(id), token, new_password)
 
   def admin_reset_password_token(conn, %{"token" => token, "new_password" => new_password}), do:
     admin_reset_password_token_p(conn, Accounts.get_user_by_password_reset_token(token), token, new_password)
@@ -176,7 +176,7 @@ defmodule MalanWeb.UserController do
   end
 
   defp is_self?(conn) do
-    conn.assigns.authed_user_id == conn.params["id"]
+    conn.assigns.authed_user_id == conn.params["id"] || conn.assigns.authed_username == conn.params["id"]
   end
 
   defp conn_to_session_info(conn) do

--- a/test/malan/accounts_test.exs
+++ b/test/malan/accounts_test.exs
@@ -24,6 +24,7 @@ defmodule Malan.AccountsTest do
 
   describe "users" do
     alias Malan.Accounts.User
+    alias Malan.Accounts.PhoneNumber
 
     test "list_users/0 returns all users" do
       user = %{user_fixture() | password: nil, custom_attrs: %{}}
@@ -529,6 +530,78 @@ defmodule Malan.AccountsTest do
         email: "capitaladdr@example.com",
         username: "capitalusername"
       } = Accounts.get_user_by(email: orig_email)
+    end
+
+    test "get_user_full/1 works" do
+      number = "123456789"
+      phone_numbers = [%{number: number}]
+      %User{id: user_id, username: username} = user_fixture(%{phone_numbers: phone_numbers})
+      assert %User{
+        id: ^user_id,
+        username: ^username,
+        phone_numbers: [%PhoneNumber{number: ^number}]
+      } = Accounts.get_user_full(user_id)
+    end
+
+    test "get_user_full/1 returns nil when not found" do
+      assert is_nil(Accounts.get_user_full(Ecto.UUID.generate))
+    end
+
+    test "get_user_full!/1 works" do
+      number = "123456789"
+      phone_numbers = [%{number: number}]
+      %User{id: user_id, username: username} = user_fixture(%{phone_numbers: phone_numbers})
+      assert %User{
+        id: ^user_id,
+        username: ^username,
+        phone_numbers: [%PhoneNumber{number: ^number}]
+      } = Accounts.get_user_full!(user_id)
+    end
+
+    test "get_user_full!/1 raises when not found" do
+      assert_raise Ecto.NoResultsError, fn -> Accounts.get_user_full!(Ecto.UUID.generate) end
+    end
+
+    test "get_user_full_by_id_or_username/1 works" do
+      number = "123456789"
+      phone_numbers = [%{number: number}]
+      %User{id: user_id, username: username} = user_fixture(%{phone_numbers: phone_numbers})
+      assert %User{
+        id: ^user_id,
+        username: ^username,
+        phone_numbers: [%PhoneNumber{number: ^number}]
+      } = Accounts.get_user_full_by_id_or_username(user_id)
+      assert %User{
+        id: ^user_id,
+        username: ^username,
+        phone_numbers: [%PhoneNumber{number: ^number}]
+      } = Accounts.get_user_full_by_id_or_username(username)
+    end
+
+    test "get_user_full_by_id_or_username/1 returns nil when not found" do
+      assert is_nil(Accounts.get_user_full_by_id_or_username(Ecto.UUID.generate))
+      assert is_nil(Accounts.get_user_full_by_id_or_username("notavalididorusernameoremailaddress"))
+    end
+
+    test "get_user_full_by_id_or_username!/1 works" do
+      number = "123456789"
+      phone_numbers = [%{number: number}]
+      %User{id: user_id, username: username} = user_fixture(%{phone_numbers: phone_numbers})
+      assert %User{
+        id: ^user_id,
+        username: ^username,
+        phone_numbers: [%PhoneNumber{number: ^number}]
+      } = Accounts.get_user_full_by_id_or_username!(user_id)
+      assert %User{
+        id: ^user_id,
+        username: ^username,
+        phone_numbers: [%PhoneNumber{number: ^number}]
+      } = Accounts.get_user_full_by_id_or_username!(username)
+    end
+
+    test "get_user_full_by_id_or_username!/1 raises when not found" do
+      assert_raise Ecto.NoResultsError, fn -> Accounts.get_user_full_by_id_or_username!(Ecto.UUID.generate) end
+      assert_raise Ecto.NoResultsError, fn -> Accounts.get_user_full_by_id_or_username!("notavalididorusernameoremailaddress") end
     end
   end
 


### PR DESCRIPTION
The client doesn't always have the user's ID but does have the username.
For situations like this it's really useful to be able to look up the
user by username instead of ID.

Fixes #29