### PR TITLE
Allow arbitary roles to be set

### DIFF
--- a/lib/malan/accounts/user.ex
+++ b/lib/malan/accounts/user.ex
@@ -145,7 +145,7 @@ defmodule Malan.Accounts.User do
 
   defp validate_roles(changeset) do
     changeset
-    |> validate_subset(:roles, ["admin", "user", "moderator"])
+    #|> validate_subset(:roles, ["admin", "user", "moderator"])
   end
 
   defp validate_username(changeset) do

--- a/test/malan/user_schema_test.exs
+++ b/test/malan/user_schema_test.exs
@@ -202,16 +202,26 @@ defmodule Malan.UserSchemaTest do
       assert tos_cs.valid? == true
     end
 
-    test "roles must be valid" do
+    #test "roles must be valid" do
+    #  changeset = Ecto.Changeset.cast(%User{}, %{roles: ["user"]}, [:roles])
+    #              |> User.validate_roles()
+    #  assert changeset.valid? == true
+
+    #  changeset = Ecto.Changeset.cast(%User{}, %{roles: ["fake"]}, [:roles])
+    #              |> User.validate_roles()
+    #  assert changeset.valid? == false
+    #  assert errors_on(changeset).roles
+    #         |> Enum.any?(fn (x) -> x =~ ~r/has an invalid entry/ end)
+    #end
+
+    test "roles can be arbitrary" do
       changeset = Ecto.Changeset.cast(%User{}, %{roles: ["user"]}, [:roles])
                   |> User.validate_roles()
       assert changeset.valid? == true
 
       changeset = Ecto.Changeset.cast(%User{}, %{roles: ["fake"]}, [:roles])
                   |> User.validate_roles()
-      assert changeset.valid? == false
-      assert errors_on(changeset).roles
-             |> Enum.any?(fn (x) -> x =~ ~r/has an invalid entry/ end)
+      assert changeset.valid? == true
     end
   end
 


### PR DESCRIPTION
You must still be an admin to set them, but there aren't restrictions
on which roles exist