### PR TITLE
Increase production logging level

### DIFF
--- a/lib/malan_web.ex
+++ b/lib/malan_web.ex
@@ -18,8 +18,10 @@ defmodule MalanWeb do
   """
 
   def controller do
+    # For tweaking log output in production:
+    # https://www.verypossible.com/insights/thoughtful-logging-in-elixir-a-phoenix-story
     quote do
-      use Phoenix.Controller, namespace: MalanWeb
+      use Phoenix.Controller, namespace: MalanWeb, log: :info
 
       import Plug.Conn
       import MalanWeb.Gettext


### PR DESCRIPTION
The really useful log messages that are buil in to phoenix are :debug
messages.  This changes them to be :info messages instead so they show
up in the logs without having to change the production log level.

See:  https://www.verypossible.com/insights/thoughtful-logging-in-elixir-a-phoenix-story

Fixes: #43