### PR TITLE
Split the prod secret into two

### DIFF
--- a/k8s/prod/deploy.yaml
+++ b/k8s/prod/deploy.yaml
@@ -37,7 +37,7 @@ spec:
           - configMapRef:
               name: malan-web-config
           - secretRef:
-              name: malan-secrets
+              name: malan-deploy-secrets
         securityContext:
           allowPrivilegeEscalation: false
 

--- a/k8s/prod/migrate.yaml
+++ b/k8s/prod/migrate.yaml
@@ -33,7 +33,7 @@ spec:
           - configMapRef:
               name: malan-migration-config
           - secretRef:
-              name: malan-secrets
+              name: malan-migration-secrets
         securityContext:
           allowPrivilegeEscalation: false
   ttlSecondsAfterFinished: 86400 # 24 hours


### PR DESCRIPTION
So that migrations will run with different credentials than the web app