### PR TITLE
Add success column to transactions

### DIFF
--- a/lib/malan/accounts.ex
+++ b/lib/malan/accounts.ex
@@ -715,6 +715,7 @@ defmodule Malan.Accounts do
     case Utils.is_uuid_or_nil?(username_or_id) do
       true ->
         record_transaction(
+          false,
           username_or_id,
           nil,
           username_or_id,
@@ -741,6 +742,7 @@ defmodule Malan.Accounts do
     case Utils.is_uuid_or_nil?(username_or_id) do
       true ->
         record_transaction(
+          false,
           username_or_id,
           nil,
           username_or_id,
@@ -767,6 +769,7 @@ defmodule Malan.Accounts do
     case Utils.is_uuid_or_nil?(username_or_id) do
       true ->
         record_transaction(
+          false,
           username_or_id,
           nil,
           username_or_id,
@@ -1434,6 +1437,7 @@ defmodule Malan.Accounts do
   Creates a transaction.  A transaction is immutable once it is created, so it
   cannot be updated later.  Make sure you have all the info you need now!
 
+  `success?` is whether the operation being logged was successful
   `user_id` is the user owning the session that made the change
   `session_id` is the session that made the change
   `who_id` is the user id of the user being changed
@@ -1452,6 +1456,7 @@ defmodule Malan.Accounts do
 
   """
   def create_transaction(
+        success?,
         user_id,
         session_id,
         who_id,
@@ -1461,7 +1466,8 @@ defmodule Malan.Accounts do
         what,
         when_utc \\ nil
       ) do
-    create_transaction(user_id, session_id, who_id, who_username, %{
+    create_transaction(success?, user_id, session_id, who_id, who_username, %{
+      "success" => success?,
       "type" => type,
       "verb" => verb,
       "what" => what,
@@ -1469,10 +1475,11 @@ defmodule Malan.Accounts do
     })
   end
 
-  def create_transaction(user_id, session_id, who_id, who_username, attrs \\ %{}) do
+  def create_transaction(success?, user_id, session_id, who_id, who_username, attrs \\ %{}) do
     %Transaction{}
     |> Transaction.create_changeset(
       Map.merge(attrs, %{
+        "success" => success?,
         "user_id" => user_id,
         "session_id" => session_id,
         "who" => who_id,
@@ -1487,8 +1494,8 @@ defmodule Malan.Accounts do
 
   Returns {:ok, transaction} on success or {:error, changeset} on failure
   """
-  def record_transaction(user_id, session_id, who, who_username, type, verb, what) do
-    case create_transaction(user_id, session_id, who, who_username, type, verb, what) do
+  def record_transaction(success?, user_id, session_id, who, who_username, type, verb, what) do
+    case create_transaction(success?, user_id, session_id, who, who_username, type, verb, what) do
       {:ok, transaction} ->
         {:ok, transaction}
 

--- a/lib/malan/accounts/transaction.ex
+++ b/lib/malan/accounts/transaction.ex
@@ -10,6 +10,7 @@ defmodule Malan.Accounts.Transaction do
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
   schema "transactions" do
+    field :success, :boolean, null: false     # Was the operation successful?
     field :type_enum, :integer, null: false   # Enum:  users || sessions
     field :verb_enum, :integer, null: false   # Action:  GET || POST || PUT || DELETE
     field :what, :string, null: false         # What was done (Human readable string)
@@ -28,13 +29,23 @@ defmodule Malan.Accounts.Transaction do
   @doc false
   def create_changeset(transaction, attrs) do
     transaction
-    |> cast(attrs, [:user_id, :session_id, :who, :who_username, :type, :verb, :when, :what])
+    |> cast(attrs, [
+      :success,
+      :user_id,
+      :session_id,
+      :who,
+      :who_username,
+      :type,
+      :verb,
+      :when,
+      :what
+    ])
     |> put_default_when()
-    |> validate_required([:type, :verb, :when, :what])
+    |> validate_required([:success, :type, :verb, :when, :what])
     |> validate_type()
     |> validate_verb()
     |> validate_who_is_binary_id_or_nil()
-    |> validate_required([:type_enum, :verb_enum, :when, :what])
+    |> validate_required([:success, :type_enum, :verb_enum, :when, :what])
     |> foreign_key_constraint(:user_id)
     |> foreign_key_constraint(:session_id)
     |> foreign_key_constraint(:who)

--- a/priv/repo/migrations/20220220023537_add_success_to_transactions.exs
+++ b/priv/repo/migrations/20220220023537_add_success_to_transactions.exs
@@ -1,0 +1,9 @@
+defmodule Malan.Repo.Migrations.AddSuccessToTransactions do
+  use Ecto.Migration
+
+  def change do
+    alter table("transactions") do
+      add :success, :boolean, null: false
+    end
+  end
+end

--- a/test/malan/accounts_test.exs
+++ b/test/malan/accounts_test.exs
@@ -1629,6 +1629,7 @@ defmodule Malan.AccountsTest do
 
       assert {:ok, %Transaction{} = transaction} =
                Accounts.create_transaction(
+                 true,
                  user.id,
                  session.id,
                  user.id,

--- a/test/malan/transaction_schema_test.exs
+++ b/test/malan/transaction_schema_test.exs
@@ -90,6 +90,7 @@ defmodule Malan.TransactionSchemaTest do
     test "#create_changeset/2 allows user id to be nil" do
       cs =
         Transaction.create_changeset(%Transaction{}, %{
+          success: true,
           sesson_id: "sid",
           who: Ecto.UUID.generate(),
           type: "users",
@@ -103,6 +104,7 @@ defmodule Malan.TransactionSchemaTest do
     test "#create_changeset/2 allows session id to be nil" do
       cs =
         Transaction.create_changeset(%Transaction{}, %{
+          success: false,
           user_id: "uid",
           who: Ecto.UUID.generate(),
           type: "users",
@@ -116,6 +118,7 @@ defmodule Malan.TransactionSchemaTest do
     test "#create_changeset/2 requires who to be a binary ID" do
       cs =
         Transaction.create_changeset(%Transaction{}, %{
+          success: true,
           user_id: "uid",
           who: Ecto.UUID.generate(),
           type: "users",

--- a/test/support/fixtures/accounts_fixtures.ex
+++ b/test/support/fixtures/accounts_fixtures.ex
@@ -33,12 +33,13 @@ defmodule Malan.AccountsFixtures do
     "when" => nil
   }
 
-  def create_transaction(nil, user, session, attrs) do
-    Accounts.create_transaction(user.id, session.id, user.id, user.username, attrs)
+  def create_transaction(success?, nil, user, session, attrs) do
+    Accounts.create_transaction(success?, user.id, session.id, user.id, user.username, attrs)
   end
 
-  def create_transaction(user_id, user, session, attrs),
-    do: Accounts.create_transaction(user_id, session.id, user.id, user.username, attrs)
+  def create_transaction(success?, user_id, user, session, attrs) do
+    Accounts.create_transaction(success?, user_id, session.id, user.id, user.username, attrs)
+  end
 
   @doc """
   Creates a transaction using the specified attrs.  Supports specifying user_id in attrs
@@ -50,6 +51,7 @@ defmodule Malan.AccountsFixtures do
          %{} = val_attrs <- Map.merge(@transaction_valid_attrs, attrs),
          {:ok, transaction} <-
            create_transaction(
+             Map.get(attrs, "success") || true,
              Map.get(attrs, "user_id"),
              user,
              session,


### PR DESCRIPTION
This way we can see whether the transaction was successful or not, and
we can query based on that.  Previously you could infer success from the
"what" contents, but it wasn't explicit.  This is explicit and
queryable.

Fixes #65