### PR TITLE
Make 422 errors with changeset info more consistent

### DIFF
--- a/lib/malan_web/controllers/fallback_controller.ex
+++ b/lib/malan_web/controllers/fallback_controller.ex
@@ -9,24 +9,26 @@ defmodule MalanWeb.FallbackController do
   """
   use MalanWeb, :controller
 
+  import MalanWeb.ChangesetView, only: [translate_errors: 1]
+
   def call(conn, {:error, %Ecto.Changeset{} = changeset}) do
     conn
     |> put_status(:unprocessable_entity)
-    |> put_view(MalanWeb.ChangesetView)
-    |> render("error.json", changeset: changeset)
+    |> put_view(MalanWeb.ErrorView)
+    |> render("422.json", errors: translate_errors(changeset))
   end
 
   def call(conn, {:error, :not_found}) do
     conn
     |> put_status(:not_found)
     |> put_view(MalanWeb.ErrorView)
-    |> render(:"404")
+    |> render("404.json")
   end
 
   def call(conn, {:error, :too_many_requests}) do
     conn
     |> put_status(:too_many_requests)
     |> put_view(MalanWeb.ErrorView)
-    |> render(:"429")
+    |> render("429.json")
   end
 end

--- a/lib/malan_web/controllers/pagination_controller.ex
+++ b/lib/malan_web/controllers/pagination_controller.ex
@@ -84,7 +84,7 @@ defmodule Malan.PaginationController do
 
       _ ->
         Logger.warning(
-          "[pagination_info]: pagination info retrieved from conn that hasn't been through the plug `validate_pagination` or `require_pagination`. There may be an endpoint that expects to be paginated but doesn't require the Plug correctly.  Because of this it will always und up with the defautl page num and default page size even if those params are included in the query string"
+          "[pagination_info]: pagination info retrieved from conn that hasn't been through the plug `validate_pagination` or `require_pagination`. There may be an endpoint that expects to be paginated but doesn't require the Plug correctly.  Because of this it will always und up with the default page num and default page size even if those params are included in the query string"
         )
 
         {Pagination.default_page_num(), Pagination.default_page_size()}

--- a/lib/malan_web/views/error_view.ex
+++ b/lib/malan_web/views/error_view.ex
@@ -1,136 +1,121 @@
 defmodule MalanWeb.ErrorView do
   use MalanWeb, :view
 
+  import MalanWeb.ChangesetView, only: [translate_errors: 1]
+
   def render("400.json", _assigns) do
     %{
-      errors: %{
-        ok: false,
-        code: 400,
-        detail: "Bad Request"
-      }
+      ok: false,
+      code: 400,
+      detail: "Bad Request",
+      message: "The request was very very bad"
     }
   end
 
   def render("401.json", _assigns) do
     %{
-      errors: %{
-        ok: false,
-        code: 401,
-        detail: "Unauthorized",
-        message: "You are authenticated but do not have access to this method on this object."
-      }
+      ok: false,
+      code: 401,
+      detail: "Unauthorized",
+      message: "You are authenticated but do not have access to this method on this object."
     }
   end
 
   def render("403.json", %{invalid_credentials: true}) do
     %{
-      errors: %{
-        ok: false,
-        code: 403,
-        detail: "Forbidden",
-        message:
-          "Username, password and/or location were invalid.  Please verify credentials and try again."
-      }
+      ok: false,
+      code: 403,
+      detail: "Forbidden",
+      message:
+        "Username, password and/or location were invalid.  Please verify credentials and try again."
     }
   end
 
   def render("403.json", _assigns) do
     %{
-      errors: %{
-        ok: false,
-        code: 403,
-        detail: "Forbidden",
-        message:
-          "Anonymous access to this method on this object is not allowed.  You must authenticate and pass a valid token."
-      }
+      ok: false,
+      code: 403,
+      detail: "Forbidden",
+      message:
+        "Anonymous access to this method on this object is not allowed.  You must authenticate and pass a valid token."
     }
   end
 
   def render("404.json", _assigns) do
     %{
-      errors: %{
-        ok: false,
-        code: 404,
-        detail: "Not Found",
-        message: "The requested object was not found."
-      }
+      ok: false,
+      code: 404,
+      detail: "Not Found",
+      message: "The requested object was not found."
     }
   end
 
   def render("422.json", assigns) do
-    msg =
-      case assigns.pagination_error do
-        nil ->
-          "The request was syntactically correct, but some or all of the parameters failed validation"
+    {errors, msg} =
+      cond do
+        Map.has_key?(assigns, :pagination_error) && not is_nil(assigns.pagination_error) ->
+          {translate_errors(assigns.pagination_error),
+           "One or both of the pagination parameters failed validation.  See errors key for details"}
 
-        _ ->
-          "One or both of the pagination parameters failed validation."
+        true ->
+          {assigns.errors,
+           "The request was syntactically correct, but some or all of the parameters failed validation.  See errors key for details"}
       end
 
     %{
-      errors: %{
-        ok: false,
-        code: 422,
-        detail: "Unprocessable Entity",
-        message: msg
-      }
+      ok: false,
+      code: 422,
+      detail: "Unprocessable Entity",
+      message: msg,
+      errors: errors
     }
   end
 
   def render("423.json", _assigns) do
     %{
-      errors: %{
-        ok: false,
-        code: 423,
-        detail: "Locked",
-        message: "The requested resource is locked.  Please contact an administrator"
-      }
+      ok: false,
+      code: 423,
+      detail: "Locked",
+      message: "The requested resource is locked.  Please contact an administrator"
     }
   end
 
   def render("429.json", _assigns) do
     %{
-      errors: %{
-        ok: false,
-        code: 429,
-        detail: "Too Many Requests",
-        message:
-          "You have exceeded the allowed number of requests.  Please cool off and try again later."
-      }
+      ok: false,
+      code: 429,
+      detail: "Too Many Requests",
+      message:
+        "You have exceeded the allowed number of requests.  Please cool off and try again later."
     }
   end
 
   def render("461.json", _assigns) do
     %{
-      errors: %{
-        ok: false,
-        code: 461,
-        detail: "Terms of Service Required",
-        message:
-          "You have not yet accepted the Terms of Service.  Acceptance is required to use this API."
-      }
+      ok: false,
+      code: 461,
+      detail: "Terms of Service Required",
+      message:
+        "You have not yet accepted the Terms of Service.  Acceptance is required to use this API."
     }
   end
 
   def render("462.json", _assigns) do
     %{
-      errors: %{
-        ok: false,
-        code: 462,
-        detail: "Privacy Policy Required",
-        message:
-          "You have not yet accepted the Privacy Policy.  Acceptance is required to use this API."
-      }
+      ok: false,
+      code: 462,
+      detail: "Privacy Policy Required",
+      message:
+        "You have not yet accepted the Privacy Policy.  Acceptance is required to use this API."
     }
   end
 
   def render("500.json", _assigns) do
     %{
-      errors: %{
-        ok: false,
-        code: 500,
-        detail: "Internal Server Error"
-      }
+      ok: false,
+      code: 500,
+      detail: "Internal Server Error",
+      message: "Internal Server Error"
     }
   end
 
@@ -139,12 +124,11 @@ defmodule MalanWeb.ErrorView do
   # "Not Found".
   def template_not_found(template, _assigns) do
     %{
-      errors: %{
-        ok: false,
-        # TODO: Can get this code from template?
-        code: 404,
-        detail: Phoenix.Controller.status_message_from_template(template)
-      }
+      ok: false,
+      # TODO: Can get this code from template?
+      code: 404,
+      detail: Phoenix.Controller.status_message_from_template(template),
+      message: "Template not found"
     }
   end
 end

--- a/test/malan_web/controllers/session_controller_test.exs
+++ b/test/malan_web/controllers/session_controller_test.exs
@@ -448,7 +448,7 @@ defmodule MalanWeb.SessionControllerTest do
           session: %{username: "invalid username", password: "something wrong"}
         )
 
-      assert %{"errors" => %{"detail" => "Forbidden"}} = json_response(conn, 403)
+      assert %{"detail" => "Forbidden"} = json_response(conn, 403)
     end
 
     test "invalid password", %{conn: conn} do
@@ -459,7 +459,7 @@ defmodule MalanWeb.SessionControllerTest do
           session: %{username: user.username, password: "incorrect password"}
         )
 
-      assert %{"errors" => %{"detail" => "Forbidden"}} = json_response(conn, 403)
+      assert %{"detail" => "Forbidden"} = json_response(conn, 403)
     end
 
     test "can be called by admin non-owner", %{conn: conn} do
@@ -708,7 +708,7 @@ defmodule MalanWeb.SessionControllerTest do
           session: %{username: user.username, password: user.password}
         )
 
-      assert %{"detail" => "Locked"} = json_response(conn, 423)["errors"]
+      assert %{"detail" => "Locked"} = json_response(conn, 423)
 
       assert [
                ^tx_locked,
@@ -739,7 +739,7 @@ defmodule MalanWeb.SessionControllerTest do
           session: %{username: bad_user_name, password: "fakeusernamespassword"}
         )
 
-      assert %{"detail" => "Forbidden"} = json_response(conn, 403)["errors"]
+      assert %{"detail" => "Forbidden"} = json_response(conn, 403)
 
       assert [
                %Transaction{
@@ -772,7 +772,7 @@ defmodule MalanWeb.SessionControllerTest do
           session: %{username: user.username, password: "fakeusernamespassword"}
         )
 
-      assert %{"detail" => "Forbidden"} = json_response(conn, 403)["errors"]
+      assert %{"detail" => "Forbidden"} = json_response(conn, 403)
 
       assert [
                %Transaction{

--- a/test/malan_web/controllers/user_controller_test.exs
+++ b/test/malan_web/controllers/user_controller_test.exs
@@ -287,7 +287,20 @@ defmodule MalanWeb.UserControllerTest do
 
     test "renders errors when data is invalid", %{conn: conn} do
       conn = post(conn, Routes.user_path(conn, :create), user: @invalid_attrs)
-      assert json_response(conn, 422)["errors"] != %{}
+
+      assert json_response(conn, 422) == %{
+        "ok" => false,
+        "code" => 422,
+        "detail" => "Unprocessable Entity",
+        "message" => "The request was syntactically correct, but some or all of the parameters failed validation.  See errors key for details",
+        "errors" => %{
+          "email" => ["can't be blank"],
+          "first_name" => ["can't be blank"],
+          "last_name" => ["can't be blank"],
+          "password_hash" => ["can't be blank"],
+          "username" => ["can't be blank"],
+        }
+      }
     end
 
     test "allows specifying initial password and requires ToS/PP", %{conn: conn} do

--- a/test/malan_web/controllers/user_controller_test.exs
+++ b/test/malan_web/controllers/user_controller_test.exs
@@ -1226,7 +1226,8 @@ defmodule MalanWeb.UserControllerTest do
       assert response(conn, 204)
 
       conn = get(conn, Routes.user_path(conn, :show, user))
-      assert %{"errors" => %{"ok" => false, "code" => 404, "detail" => "Not Found"}} =
+
+      assert %{"ok" => false, "code" => 404, "detail" => "Not Found"} =
                json_response(conn, 404)
     end
 
@@ -1240,7 +1241,8 @@ defmodule MalanWeb.UserControllerTest do
       assert response(conn, 204)
 
       conn = get(conn, Routes.user_path(conn, :show, user))
-      assert %{"errors" => %{"ok" => false, "code" => 404, "detail" => "Not Found"}} =
+
+      assert %{"ok" => false, "code" => 404, "detail" => "Not Found"} =
                json_response(conn, 404)
 
       assert [
@@ -1366,7 +1368,7 @@ defmodule MalanWeb.UserControllerTest do
     test "Returns 404 when user is not found", %{conn: conn} do
       conn = post(conn, Routes.user_path(conn, :reset_password, "invaliduser"))
 
-      assert %{"errors" => %{"ok" => false, "code" => 404, "detail" => "Not Found"}} =
+      assert %{"ok" => false, "code" => 404, "detail" => "Not Found"} =
                json_response(conn, 404)
     end
 
@@ -1436,8 +1438,7 @@ defmodule MalanWeb.UserControllerTest do
           session: %{username: user.username, password: user.password}
         )
 
-      assert %{"errors" => %{"ok" => false, "code" => 403, "detail" => "Forbidden"}} =
-               json_response(conn, 403)
+      assert %{"ok" => false, "code" => 403, "detail" => "Forbidden"} = json_response(conn, 403)
 
       # Now login with new password to make sure it works
       conn =
@@ -1494,8 +1495,7 @@ defmodule MalanWeb.UserControllerTest do
           session: %{username: user.username, password: new_password}
         )
 
-      assert %{"errors" => %{"ok" => false, "code" => 403, "detail" => "Forbidden"}} =
-               json_response(conn, 403)
+      assert %{"ok" => false, "code" => 403, "detail" => "Forbidden"} = json_response(conn, 403)
 
       # Try to login with old password and ensure it works
       conn =
@@ -1546,8 +1546,7 @@ defmodule MalanWeb.UserControllerTest do
           session: %{username: user.username, password: user.password}
         )
 
-      assert %{"errors" => %{"ok" => false, "code" => 403, "detail" => "Forbidden"}} =
-               json_response(conn, 403)
+      assert %{"ok" => false, "code" => 403, "detail" => "Forbidden"} = json_response(conn, 403)
 
       # Now login with new password to make sure it works
       conn =
@@ -1633,7 +1632,7 @@ defmodule MalanWeb.UserControllerTest do
           session: %{username: user.username, password: new_password}
         )
 
-      assert %{"errors" => %{"ok" => false, "code" => 403, "detail" => "Forbidden"}} =
+      assert %{"ok" => false, "code" => 403, "detail" => "Forbidden"} =
                json_response(conn, 403)
 
       # Now login with the old password to make sure it still works
@@ -1666,7 +1665,7 @@ defmodule MalanWeb.UserControllerTest do
           session: %{username: user.username, password: user.password}
         )
 
-      assert %{"errors" => %{"ok" => false, "code" => 403, "detail" => "Forbidden"}} =
+      assert %{"ok" => false, "code" => 403, "detail" => "Forbidden"} =
                json_response(conn, 403)
 
       # Try to login with new password and ensure it works
@@ -1699,13 +1698,13 @@ defmodule MalanWeb.UserControllerTest do
       # Get a second password reset token.  This should get rate limited
       conn = post(conn, Routes.user_path(conn, :reset_password, user_id))
 
-      assert %{"errors" => %{"ok" => false, "code" => 429, "detail" => "Too Many Requests"}} =
+      assert %{"ok" => false, "code" => 429, "detail" => "Too Many Requests"} =
                json_response(conn, 429)
 
       # Try a third time.  Still rate limited
       conn = post(conn, Routes.user_path(conn, :reset_password, user_id))
 
-      assert %{"errors" => %{"ok" => false, "code" => 429, "detail" => "Too Many Requests"}} =
+      assert %{"ok" => false, "code" => 429, "detail" => "Too Many Requests"} =
                json_response(conn, 429)
     end
 
@@ -1751,7 +1750,7 @@ defmodule MalanWeb.UserControllerTest do
           session: %{username: user.username, password: new_password}
         )
 
-      assert %{"errors" => %{"ok" => false, "code" => 403, "detail" => "Forbidden"}} =
+      assert %{"ok" => false, "code" => 403, "detail" => "Forbidden"} =
                json_response(conn, 403)
 
       # Now login with the old password to make sure it still works
@@ -1805,7 +1804,7 @@ defmodule MalanWeb.UserControllerTest do
           session: %{username: user.username, password: user.password}
         )
 
-      assert %{"errors" => %{"ok" => false, "code" => 403, "detail" => "Forbidden"}} =
+      assert %{"ok" => false, "code" => 403, "detail" => "Forbidden"} =
                json_response(conn, 403)
 
       # Now login with new password to make sure it works
@@ -1829,7 +1828,7 @@ defmodule MalanWeb.UserControllerTest do
 
       # assert %{"ok" => false, "err" => "missing_password_reset_token", "msg" => _} = json_response(conn, 401)
       # For now just accept a 404
-      assert %{"errors" => %{"ok" => false, "code" => 404, "detail" => "Not Found"}} =
+      assert %{"ok" => false, "code" => 404, "detail" => "Not Found"} =
                json_response(conn, 404)
     end
 
@@ -1860,7 +1859,7 @@ defmodule MalanWeb.UserControllerTest do
 
       # assert %{"ok" => false, "err" => "invalid_password_reset_token", "msg" => _} = json_response(conn, 401)
       # For now just accept a 404
-      assert %{"errors" => %{"ok" => false, "code" => 404, "detail" => "Not Found"}} =
+      assert %{"ok" => false, "code" => 404, "detail" => "Not Found"} =
                json_response(conn, 404)
 
       # Try to login with new password and make sure it doesn't work
@@ -1869,7 +1868,7 @@ defmodule MalanWeb.UserControllerTest do
           session: %{username: user.username, password: new_password}
         )
 
-      assert %{"errors" => %{"ok" => false, "code" => 403, "detail" => "Forbidden"}} =
+      assert %{"ok" => false, "code" => 403, "detail" => "Forbidden"} =
                json_response(conn, 403)
 
       # Try to login with old password and ensure it works
@@ -1923,7 +1922,7 @@ defmodule MalanWeb.UserControllerTest do
           session: %{username: user.username, password: user.password}
         )
 
-      assert %{"errors" => %{"ok" => false, "code" => 403, "detail" => "Forbidden"}} =
+      assert %{"ok" => false, "code" => 403, "detail" => "Forbidden"} =
                json_response(conn, 403)
 
       # Now login with new password to make sure it works
@@ -1942,7 +1941,7 @@ defmodule MalanWeb.UserControllerTest do
 
       # assert %{"ok" => false, "err" => "missing_password_reset_token", "msg" => _} = json_response(conn, 401)
       # For now just accept a 404
-      assert %{"errors" => %{"ok" => false, "code" => 404, "detail" => "Not Found"}} =
+      assert %{"ok" => false, "code" => 404, "detail" => "Not Found"} =
                json_response(conn, 404)
     end
 
@@ -1996,7 +1995,7 @@ defmodule MalanWeb.UserControllerTest do
 
       # assert %{"ok" => false, "err" => "invalid_password_reset_token", "msg" => _} = json_response(conn, 401)
       # For now just accept a 404
-      assert %{"errors" => %{"ok" => false, "code" => 404, "detail" => "Not Found"}} =
+      assert %{"ok" => false, "code" => 404, "detail" => "Not Found"} =
                json_response(conn, 404)
 
       # Try to login with new password and ensure it doesn't work
@@ -2005,7 +2004,7 @@ defmodule MalanWeb.UserControllerTest do
           session: %{username: user.username, password: new_password}
         )
 
-      assert %{"errors" => %{"ok" => false, "code" => 403, "detail" => "Forbidden"}} =
+      assert %{"ok" => false, "code" => 403, "detail" => "Forbidden"} =
                json_response(conn, 403)
 
       # Now login with the old password to make sure it still works
@@ -2031,7 +2030,7 @@ defmodule MalanWeb.UserControllerTest do
           session: %{username: user.username, password: user.password}
         )
 
-      assert %{"errors" => %{"ok" => false, "code" => 403, "detail" => "Forbidden"}} =
+      assert %{"ok" => false, "code" => 403, "detail" => "Forbidden"} =
                json_response(conn, 403)
 
       # Try to login with new password and ensure it works
@@ -2083,8 +2082,7 @@ defmodule MalanWeb.UserControllerTest do
           session: %{username: user.username, password: new_password}
         )
 
-      assert %{"errors" => %{"ok" => false, "code" => 403, "detail" => "Forbidden"}} =
-               json_response(conn, 403)
+      assert %{"ok" => false, "code" => 403, "detail" => "Forbidden"} = json_response(conn, 403)
 
       # Now login with the old password to make sure it still works
       conn =
@@ -2222,8 +2220,7 @@ defmodule MalanWeb.UserControllerTest do
           session: %{username: user.username, password: user.password}
         )
 
-      assert %{"errors" => %{"ok" => false, "code" => 403, "detail" => "Forbidden"}} =
-               json_response(conn, 403)
+      assert %{"ok" => false, "code" => 403, "detail" => "Forbidden"} = json_response(conn, 403)
 
       # Now login with new password to make sure it works
       conn =
@@ -2288,8 +2285,7 @@ defmodule MalanWeb.UserControllerTest do
           session: %{username: user.username, password: new_password}
         )
 
-      assert %{"errors" => %{"ok" => false, "code" => 403, "detail" => "Forbidden"}} =
-               json_response(conn, 403)
+      assert %{"ok" => false, "code" => 403, "detail" => "Forbidden"} = json_response(conn, 403)
 
       # Try to login with old password and ensure it works
       conn =
@@ -2340,8 +2336,7 @@ defmodule MalanWeb.UserControllerTest do
           session: %{username: user.username, password: user.password}
         )
 
-      assert %{"errors" => %{"ok" => false, "code" => 403, "detail" => "Forbidden"}} =
-               json_response(conn, 403)
+      assert %{"ok" => false, "code" => 403, "detail" => "Forbidden"} = json_response(conn, 403)
 
       # Now login with new password to make sure it works
       conn =
@@ -2423,8 +2418,7 @@ defmodule MalanWeb.UserControllerTest do
           session: %{username: user.username, password: new_password}
         )
 
-      assert %{"errors" => %{"ok" => false, "code" => 403, "detail" => "Forbidden"}} =
-               json_response(conn, 403)
+      assert %{"ok" => false, "code" => 403, "detail" => "Forbidden"} = json_response(conn, 403)
 
       # Now login with the old password to make sure it still works
       conn =
@@ -2458,8 +2452,7 @@ defmodule MalanWeb.UserControllerTest do
           session: %{username: user.username, password: user.password}
         )
 
-      assert %{"errors" => %{"ok" => false, "code" => 403, "detail" => "Forbidden"}} =
-               json_response(conn, 403)
+      assert %{"ok" => false, "code" => 403, "detail" => "Forbidden"} = json_response(conn, 403)
 
       # Try to login with new password and ensure it works
       conn =
@@ -2512,7 +2505,7 @@ defmodule MalanWeb.UserControllerTest do
           session: %{username: user.username, password: new_password}
         )
 
-      assert %{"errors" => %{"ok" => false, "code" => 403, "detail" => "Forbidden"}} =
+      assert %{"ok" => false, "code" => 403, "detail" => "Forbidden"} =
                json_response(conn, 403)
 
       # Now login with the old password to make sure it still works
@@ -2578,7 +2571,7 @@ defmodule MalanWeb.UserControllerTest do
           session: %{username: user.username, password: user.password}
         )
 
-      assert %{"errors" => %{"ok" => false, "code" => 403, "detail" => "Forbidden"}} =
+      assert %{"ok" => false, "code" => 403, "detail" => "Forbidden"} =
                json_response(conn, 403)
 
       # Now login with new password to make sure it works
@@ -2606,7 +2599,7 @@ defmodule MalanWeb.UserControllerTest do
 
       # assert %{"ok" => false, "err" => "missing_password_reset_token", "msg" => _} = json_response(conn, 401)
       # For now just accept a 404
-      assert %{"errors" => %{"ok" => false, "code" => 404, "detail" => "Not Found"}} =
+      assert %{"ok" => false, "code" => 404, "detail" => "Not Found"} =
                json_response(conn, 404)
     end
 
@@ -2637,7 +2630,7 @@ defmodule MalanWeb.UserControllerTest do
 
       # assert %{"ok" => false, "err" => "invalid_password_reset_token", "msg" => _} = json_response(conn, 401)
       # For now just accept a 404
-      assert %{"errors" => %{"ok" => false, "code" => 404, "detail" => "Not Found"}} =
+      assert %{"ok" => false, "code" => 404, "detail" => "Not Found"} =
                json_response(conn, 404)
 
       # Try to login with new password and make sure it doesn't work
@@ -2646,7 +2639,7 @@ defmodule MalanWeb.UserControllerTest do
           session: %{username: user.username, password: new_password}
         )
 
-      assert %{"errors" => %{"ok" => false, "code" => 403, "detail" => "Forbidden"}} =
+      assert %{"ok" => false, "code" => 403, "detail" => "Forbidden"} =
                json_response(conn, 403)
 
       # Try to login with old password and ensure it works
@@ -2700,7 +2693,7 @@ defmodule MalanWeb.UserControllerTest do
           session: %{username: user.username, password: user.password}
         )
 
-      assert %{"errors" => %{"ok" => false, "detail" => "Forbidden"}} = json_response(conn, 403)
+      assert %{"ok" => false, "detail" => "Forbidden"} = json_response(conn, 403)
 
       # Now login with new password to make sure it works
       conn =
@@ -2720,7 +2713,7 @@ defmodule MalanWeb.UserControllerTest do
 
       # assert %{"ok" => false, "err" => "missing_password_reset_token", "msg" => _} = json_response(conn, 401)
       # For now just accept a 404
-      assert %{"errors" => %{"ok" => false, "code" => 404, "detail" => "Not Found"}} =
+      assert %{"ok" => false, "code" => 404, "detail" => "Not Found"} =
                json_response(conn, 404)
     end
 
@@ -2768,7 +2761,7 @@ defmodule MalanWeb.UserControllerTest do
 
       # assert %{"ok" => false, "err" => "invalid_password_reset_token", "msg" => _} = json_response(conn, 401)
       # For now just accept a 404
-      assert %{"errors" => %{"ok" => false, "code" => 404, "detail" => "Not Found"}} =
+      assert %{"ok" => false, "code" => 404, "detail" => "Not Found"} =
                json_response(conn, 404)
 
       # Try to login with new password and ensure it doesn't work
@@ -2777,7 +2770,7 @@ defmodule MalanWeb.UserControllerTest do
           session: %{username: user.username, password: new_password}
         )
 
-      assert %{"errors" => %{"ok" => false, "code" => 403, "detail" => "Forbidden"}} =
+      assert %{"ok" => false, "code" => 403, "detail" => "Forbidden"} =
                json_response(conn, 403)
 
       # Now login with the old password to make sure it still works
@@ -2805,7 +2798,7 @@ defmodule MalanWeb.UserControllerTest do
           session: %{username: user.username, password: user.password}
         )
 
-      assert %{"errors" => %{"ok" => false, "code" => 403, "detail" => "Forbidden"}} =
+      assert %{"ok" => false, "code" => 403, "detail" => "Forbidden"} =
                json_response(conn, 403)
 
       # Try to login with new password and ensure it works
@@ -2857,7 +2850,7 @@ defmodule MalanWeb.UserControllerTest do
           session: %{username: user.username, password: new_password}
         )
 
-      assert %{"errors" => %{"ok" => false, "code" => 403, "detail" => "Forbidden"}} =
+      assert %{"ok" => false, "code" => 403, "detail" => "Forbidden"} =
                json_response(conn, 403)
 
       # Now login with the old password to make sure it still works

--- a/test/malan_web/views/error_view_test.exs
+++ b/test/malan_web/views/error_view_test.exs
@@ -6,81 +6,113 @@ defmodule MalanWeb.ErrorViewTest do
 
   test "renders 400.json" do
     assert render(MalanWeb.ErrorView, "400.json", []) == %{
-             errors: %{
-               ok: false,
-               code: 400,
-               detail: "Bad Request"
-             }
+             ok: false,
+             code: 400,
+             detail: "Bad Request",
+             message: "The request was very very bad"
            }
   end
 
   test "renders 401.json" do
     assert render(MalanWeb.ErrorView, "401.json", []) == %{
-             errors: %{
-               ok: false,
-               code: 401,
-               detail: "Unauthorized",
-               message:
-                 "You are authenticated but do not have access to this method on this object."
-             }
+             ok: false,
+             code: 401,
+             detail: "Unauthorized",
+             message:
+               "You are authenticated but do not have access to this method on this object."
            }
   end
 
   test "renders 403.json" do
     assert render(MalanWeb.ErrorView, "403.json", []) == %{
-             errors: %{
-               ok: false,
-               code: 403,
-               detail: "Forbidden",
-               message:
-                 "Anonymous access to this method on this object is not allowed.  You must authenticate and pass a valid token."
-             }
+             ok: false,
+             code: 403,
+             detail: "Forbidden",
+             message:
+               "Anonymous access to this method on this object is not allowed.  You must authenticate and pass a valid token."
            }
   end
 
   test "renders 404.json" do
     assert render(MalanWeb.ErrorView, "404.json", []) == %{
-             errors: %{
-               ok: false,
-               code: 404,
-               detail: "Not Found",
-               message: "The requested object was not found."
-             }
+             ok: false,
+             code: 404,
+             detail: "Not Found",
+             message: "The requested object was not found."
+           }
+  end
+
+  test "renders 422.json" do
+    errors = %{
+      dean: "winchester",
+      sam: "winchester"
+    }
+
+    assert render(MalanWeb.ErrorView, "422.json", pagination_error: nil, errors: errors) == %{
+             ok: false,
+             code: 422,
+             detail: "Unprocessable Entity",
+             message:
+               "The request was syntactically correct, but some or all of the parameters failed validation.  See errors key for details",
+             errors: errors
+           }
+
+    assert render(MalanWeb.ErrorView, "422.json", pagination_error: nil, errors: errors) == %{
+             ok: false,
+             code: 422,
+             detail: "Unprocessable Entity",
+             message:
+               "The request was syntactically correct, but some or all of the parameters failed validation.  See errors key for details",
+             errors: errors
+           }
+  end
+
+  test "renders 423.json" do
+    assert render(MalanWeb.ErrorView, "423.json", []) == %{
+             ok: false,
+             code: 423,
+             detail: "Locked",
+             message: "The requested resource is locked.  Please contact an administrator"
+           }
+  end
+
+  test "renders 429.json" do
+    assert render(MalanWeb.ErrorView, "429.json", []) == %{
+             ok: false,
+             code: 429,
+             detail: "Too Many Requests",
+             message:
+               "You have exceeded the allowed number of requests.  Please cool off and try again later."
            }
   end
 
   test "renders 461.json" do
     assert render(MalanWeb.ErrorView, "461.json", []) == %{
-             errors: %{
-               ok: false,
-               code: 461,
-               detail: "Terms of Service Required",
-               message:
-                 "You have not yet accepted the Terms of Service.  Acceptance is required to use this API."
-             }
+             ok: false,
+             code: 461,
+             detail: "Terms of Service Required",
+             message:
+               "You have not yet accepted the Terms of Service.  Acceptance is required to use this API."
            }
   end
 
   test "renders 462.json" do
     assert render(MalanWeb.ErrorView, "462.json", []) == %{
-             errors: %{
-               ok: false,
-               code: 462,
-               detail: "Privacy Policy Required",
-               message:
-                 "You have not yet accepted the Privacy Policy.  Acceptance is required to use this API."
-             }
+             ok: false,
+             code: 462,
+             detail: "Privacy Policy Required",
+             message:
+               "You have not yet accepted the Privacy Policy.  Acceptance is required to use this API."
            }
   end
 
   test "renders 500.json" do
     assert render(MalanWeb.ErrorView, "500.json", []) ==
              %{
-               errors: %{
-                 ok: false,
-                 code: 500,
-                 detail: "Internal Server Error"
-               }
+               ok: false,
+               code: 500,
+               detail: "Internal Server Error",
+               message: "Internal Server Error"
              }
   end
 end


### PR DESCRIPTION
Without throwing away useful data for the user.  This also removes the
errors attribute and makes the children root level members.

Improves response when pagination is incorrect.

Updates all tests and fix a few bugs ran into

Fixes #99
Fixes FreedomBen/libmalan#24