### PR TITLE
Include expired in 403

### DIFF
--- a/lib/malan/accounts.ex
+++ b/lib/malan/accounts.ex
@@ -1712,7 +1712,7 @@ defmodule Malan.Accounts do
 
     # TODO:  Switch to Malan.Sentry.capture_message to avoid log messages
     # about missing DSN in environments where there is no DSN
-    #Malan.Sentry.capture_message(msg, opts)
+    # Malan.Sentry.capture_message(msg, opts)
 
     {:error, changeset}
   end

--- a/lib/malan/accounts.ex
+++ b/lib/malan/accounts.ex
@@ -1022,6 +1022,9 @@ defmodule Malan.Accounts do
 
   def session_revoked?(revoked_at), do: !!revoked_at
 
+  def session_expired?(%Session{expires_at: expires_at} = session),
+    do: session_expired?(expires_at)
+
   def session_expired?(expires_at),
     do: DateTime.compare(expires_at, DateTime.utc_now()) == :lt
 

--- a/lib/malan/accounts/session.ex
+++ b/lib/malan/accounts/session.ex
@@ -45,9 +45,7 @@ defmodule Malan.Accounts.Session do
       :api_token,
       :expires_at,
       :authenticated_at,
-      :revoked_at,
-      :ip_address,
-      :location
+      :ip_address
     ])
   end
 

--- a/lib/malan/utils.ex
+++ b/lib/malan/utils.ex
@@ -586,13 +586,13 @@ defmodule Malan.Utils.Phoenix.Controller do
 
   require Logger
 
-  def halt_status(conn, status) do
+  def halt_status(conn, status, details \\ %{}) do
     Logger.debug("[halt_status]: status: #{status}")
 
     conn
     |> put_status(status)
     |> Phoenix.Controller.put_view(MalanWeb.ErrorView)
-    |> Phoenix.Controller.render("#{status}.json")
+    |> Phoenix.Controller.render("#{status}.json", details)
     |> halt()
   end
 

--- a/lib/malan_web/controllers/auth_controller.ex
+++ b/lib/malan_web/controllers/auth_controller.ex
@@ -17,9 +17,9 @@ defmodule Malan.AuthController do
 
     case conn.assigns do
       %{auth_error: nil} -> conn
-      %{auth_error: {:error, :expired}} -> halt_status(conn, 401)
-      %{auth_error: {:error, :revoked}} -> halt_status(conn, 401)
-      %{auth_error: {:error, :not_found}} -> halt_status(conn, 403)
+      %{auth_error: {:error, :revoked}} -> halt_status(conn, 403, %{token_revoked: true})
+      %{auth_error: {:error, :expired}} -> halt_status(conn, 403, %{token_expired: true})
+      %{auth_error: {:error, :not_found}} -> halt_status(conn, 403, %{token_not_found: true})
       _ -> halt_status(conn, 403)
     end
   end

--- a/lib/malan_web/controllers/auth_controller.ex
+++ b/lib/malan_web/controllers/auth_controller.ex
@@ -17,9 +17,9 @@ defmodule Malan.AuthController do
 
     case conn.assigns do
       %{auth_error: nil} -> conn
-      %{auth_error: {:error, :revoked}} -> halt_status(conn, 403, %{token_revoked: true})
-      %{auth_error: {:error, :expired}} -> halt_status(conn, 403, %{token_expired: true})
-      %{auth_error: {:error, :not_found}} -> halt_status(conn, 403, %{token_not_found: true})
+      %{auth_error: :expired} -> halt_status(conn, 403, %{token_expired: true})
+      %{auth_error: :revoked} -> halt_status(conn, 403, %{token_revoked: true})
+      %{auth_error: :not_found} -> halt_status(conn, 403, %{token_not_found: true})
       _ -> halt_status(conn, 403)
     end
   end

--- a/lib/malan_web/controllers/user_controller.ex
+++ b/lib/malan_web/controllers/user_controller.ex
@@ -306,19 +306,6 @@ defmodule MalanWeb.UserController do
 
       {:error, err} ->
         render_token_error(conn, err)
-
-        #TODO
-      {:error, :revoked} ->
-        render(conn, "403.json", %{token_revoked: true})
-
-      {:error, :expired} ->
-        render(conn, "403.json", %{token_expired: true})
-
-      {:error, :not_found} ->
-        render(conn, "404.json", %{})
-
-      {:error, _} ->
-        render(conn, "404.json", %{})
     end
   end
 
@@ -358,10 +345,11 @@ defmodule MalanWeb.UserController do
         {:error, err_cs} ->
           err_str = Utils.Ecto.Changeset.errors_to_str(err_cs)
 
-          cs_or_atom = case err_cs do
-                         :too_many_requests -> changeset
-                         _ -> err_cs
-                       end
+          cs_or_atom =
+            case err_cs do
+              :too_many_requests -> changeset
+              _ -> err_cs
+            end
 
           record_transaction(
             conn,
@@ -591,22 +579,22 @@ defmodule MalanWeb.UserController do
   end
 
   defp render_token_error(conn, :expired) do
-    render_token_error(conn, 403, :expired, %{token_expired: true})
+    render_token_error(conn, 403, %{token_expired: true})
   end
 
   defp render_token_error(conn, :revoked) do
-    render_token_error(conn, 403, :revoked, %{token_revoked: true})
+    render_token_error(conn, 403, %{token_revoked: true})
   end
 
   defp render_token_error(conn, :not_found) do
-    render_token_error(conn, 404, :not_found)
+    render_token_error(conn, 404)
   end
 
   defp render_token_error(conn, error) when is_atom(error) do
-    render_token_error(conn, 404, :not_found)
+    render_token_error(conn, 403)
   end
 
-  defp render_token_error(conn, status, error, details \\ %{}) do
+  defp render_token_error(conn, status, details \\ %{}) do
     conn
     |> put_status(status)
     |> put_view(MalanWeb.ErrorView)

--- a/lib/malan_web/controllers/user_controller.ex
+++ b/lib/malan_web/controllers/user_controller.ex
@@ -304,11 +304,21 @@ defmodule MalanWeb.UserController do
           pp
         )
 
-      # {:error, :revoked}
-      # {:error, :expired}
-      # {:error, :not_found}
+      {:error, err} ->
+        render_token_error(conn, err)
+
+        #TODO
+      {:error, :revoked} ->
+        render(conn, "403.json", %{token_revoked: true})
+
+      {:error, :expired} ->
+        render(conn, "403.json", %{token_expired: true})
+
+      {:error, :not_found} ->
+        render(conn, "404.json", %{})
+
       {:error, _} ->
-        send_resp(conn, :not_found, "")
+        render(conn, "404.json", %{})
     end
   end
 
@@ -578,6 +588,29 @@ defmodule MalanWeb.UserController do
       password_reset_token: user.password_reset_token,
       password_reset_token_expires_at: user.password_reset_token_expires_at
     )
+  end
+
+  defp render_token_error(conn, :expired) do
+    render_token_error(conn, 403, :expired, %{token_expired: true})
+  end
+
+  defp render_token_error(conn, :revoked) do
+    render_token_error(conn, 403, :revoked, %{token_revoked: true})
+  end
+
+  defp render_token_error(conn, :not_found) do
+    render_token_error(conn, 404, :not_found)
+  end
+
+  defp render_token_error(conn, error) when is_atom(error) do
+    render_token_error(conn, 404, :not_found)
+  end
+
+  defp render_token_error(conn, status, error, details \\ %{}) do
+    conn
+    |> put_status(status)
+    |> put_view(MalanWeb.ErrorView)
+    |> render("#{status}.json", details)
   end
 
   defp is_self_or_admin(conn, _opts) do

--- a/lib/malan_web/views/error_view.ex
+++ b/lib/malan_web/views/error_view.ex
@@ -31,6 +31,28 @@ defmodule MalanWeb.ErrorView do
     }
   end
 
+  def render("403.json", %{token_expired: true}) do
+    %{
+      ok: false,
+      code: 403,
+      detail: "Forbidden",
+      message: "API token is expired or revoked",
+      token_expired: true,
+      errors: [%{token: ["expired"]}]
+    }
+  end
+
+  def render("403.json", %{token_revoked: true}) do
+    %{
+      ok: false,
+      code: 403,
+      detail: "Forbidden",
+      message: "API token is expired or revoked",
+      token_expired: true,
+      errors: [%{token: ["expired"]}]
+    }
+  end
+
   def render("403.json", _assigns) do
     %{
       ok: false,

--- a/scripts/curl/session_token_expires.sh
+++ b/scripts/curl/session_token_expires.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+#VERBOSE='-v'
+VERBOSE=''
+
+MALAN_ENDPOINT='http://localhost:4000'
+#MALAN_ENDPOINT='https://malan-staging.ameelio.org'
+#MALAN_ENDPOINT='https://malan.ameelio.org'
+
+USERNAME='root'
+PASSWORD='password10'
+
+api_token="$(curl -s \
+               --request POST \
+               --header "Accept: application/json" \
+               --header "Content-Type: application/json" \
+               --data "{\"session\":{\"username\":\"${USERNAME}\",\"password\":\"${PASSWORD}\",\"expires_in_seconds\":3}}" \
+               "${MALAN_ENDPOINT}/api/sessions/" \
+              | jq -r .data.api_token)"
+
+echo
+echo "Got api token:  ${api_token}"
+echo
+echo "Verifying token through whoami..."
+echo
+
+curl -s ${VERBOSE} \
+  --request GET \
+  --header "Accept: application/json" \
+  --header "Content-Type: application/json" \
+  --header "Authorization: Bearer ${api_token}" \
+  "${MALAN_ENDPOINT}/api/users/whoami" \
+  | jq -r
+  
+
+echo
+echo "Waiting 5 seconds for token to expire ..."
+echo
+sleep 10
+
+curl -s ${VERBOSE} \
+  --request GET \
+  --header "Accept: application/json" \
+  --header "Content-Type: application/json" \
+  --header "Authorization: Bearer ${api_token}" \
+  "${MALAN_ENDPOINT}/api/users/whoami" \
+  | jq -r
+  

--- a/test/malan/accounts_test.exs
+++ b/test/malan/accounts_test.exs
@@ -1386,6 +1386,16 @@ defmodule Malan.AccountsTest do
                  "127.0.0.1"
                )
     end
+
+    test "session_expired?/1" do
+      session = session_fixture()
+      assert false == Accounts.session_expired?(session)
+      assert false == Accounts.session_expired?(session.expires_at)
+
+      session = Helpers.Accounts.set_expired(session)
+      assert true == Accounts.session_expired?(session)
+      assert true == Accounts.session_expired?(session.expires_at)
+    end
   end
 
   # describe "teams" do

--- a/test/malan_web/controllers/user_controller_test.exs
+++ b/test/malan_web/controllers/user_controller_test.exs
@@ -105,7 +105,11 @@ defmodule MalanWeb.UserControllerTest do
   describe "show" do
     setup [:create_regular_user_with_session]
 
-    test "Rejects with 403 when expired", %{conn: conn, user: %User{id: id} = user, session: %Session{} = session} do
+    test "Rejects with 403 when expired", %{
+      conn: conn,
+      user: %User{id: id} = _user,
+      session: %Session{} = session
+    } do
       session = Helpers.Accounts.set_expired(session)
       assert TestUtils.DateTime.within_last?(session.expires_at, 20, :seconds)
 
@@ -113,15 +117,19 @@ defmodule MalanWeb.UserControllerTest do
       conn = get(conn, Routes.user_path(conn, :show, id))
 
       assert %{
-        "ok" => false,
-        "code" => 403,
-        "detail" => "Forbidden",
-        "message" => "API token is expired or revoked",
-        "token_expired" => true,
+               "ok" => false,
+               "code" => 403,
+               "detail" => "Forbidden",
+               "message" => "API token is expired or revoked",
+               "token_expired" => true
              } = json_response(conn, 403)
     end
 
-    test "Rejects with 403 when revoked", %{conn: conn, user: %User{id: id} = user, session: %Session{} = session} do
+    test "Rejects with 403 when revoked", %{
+      conn: conn,
+      user: %User{id: id} = _user,
+      session: %Session{} = session
+    } do
       assert is_nil(session.revoked_at)
       session = Helpers.Accounts.set_revoked(session)
       assert true == TestUtils.DateTime.within_last?(session.revoked_at, 2, :seconds)
@@ -130,11 +138,11 @@ defmodule MalanWeb.UserControllerTest do
       conn = get(conn, Routes.user_path(conn, :show, id))
 
       assert %{
-        "ok" => false,
-        "code" => 403,
-        "detail" => "Forbidden",
-        "message" => "API token is expired or revoked",
-        "token_expired" => true,
+               "ok" => false,
+               "code" => 403,
+               "detail" => "Forbidden",
+               "message" => "API token is expired or revoked",
+               "token_expired" => true
              } = json_response(conn, 403)
     end
   end
@@ -326,18 +334,19 @@ defmodule MalanWeb.UserControllerTest do
       conn = post(conn, Routes.user_path(conn, :create), user: @invalid_attrs)
 
       assert json_response(conn, 422) == %{
-        "ok" => false,
-        "code" => 422,
-        "detail" => "Unprocessable Entity",
-        "message" => "The request was syntactically correct, but some or all of the parameters failed validation.  See errors key for details",
-        "errors" => %{
-          "email" => ["can't be blank"],
-          "first_name" => ["can't be blank"],
-          "last_name" => ["can't be blank"],
-          "password_hash" => ["can't be blank"],
-          "username" => ["can't be blank"],
-        }
-      }
+               "ok" => false,
+               "code" => 422,
+               "detail" => "Unprocessable Entity",
+               "message" =>
+                 "The request was syntactically correct, but some or all of the parameters failed validation.  See errors key for details",
+               "errors" => %{
+                 "email" => ["can't be blank"],
+                 "first_name" => ["can't be blank"],
+                 "last_name" => ["can't be blank"],
+                 "password_hash" => ["can't be blank"],
+                 "username" => ["can't be blank"]
+               }
+             }
     end
 
     test "allows specifying initial password and requires ToS/PP", %{conn: conn} do
@@ -1277,8 +1286,7 @@ defmodule MalanWeb.UserControllerTest do
 
       conn = get(conn, Routes.user_path(conn, :show, user))
 
-      assert %{"ok" => false, "code" => 404, "detail" => "Not Found"} =
-               json_response(conn, 404)
+      assert %{"ok" => false, "code" => 404, "detail" => "Not Found"} = json_response(conn, 404)
     end
 
     test "Creates a corresponding transaction", %{
@@ -1292,8 +1300,7 @@ defmodule MalanWeb.UserControllerTest do
 
       conn = get(conn, Routes.user_path(conn, :show, user))
 
-      assert %{"ok" => false, "code" => 404, "detail" => "Not Found"} =
-               json_response(conn, 404)
+      assert %{"ok" => false, "code" => 404, "detail" => "Not Found"} = json_response(conn, 404)
 
       assert [
                %Transaction{
@@ -1390,7 +1397,11 @@ defmodule MalanWeb.UserControllerTest do
       assert conn.status == 403
     end
 
-    test "Rejects with 403 when expired", %{conn: conn, user: %User{} = user, session: %Session{} = session} do
+    test "Rejects with 403 when expired", %{
+      conn: conn,
+      user: %User{} = _user,
+      session: %Session{} = session
+    } do
       assert not Accounts.session_expired?(session)
       session = Helpers.Accounts.set_expired(session)
       assert Accounts.session_expired?(session)
@@ -1399,15 +1410,19 @@ defmodule MalanWeb.UserControllerTest do
       conn = get(conn, Routes.user_path(conn, :whoami))
 
       assert %{
-        "ok" => false,
-        "code" => 403,
-        "detail" => "Forbidden",
-        "message" => "API token is expired or revoked",
-        "token_expired" => true,
+               "ok" => false,
+               "code" => 403,
+               "detail" => "Forbidden",
+               "message" => "API token is expired or revoked",
+               "token_expired" => true
              } = json_response(conn, 403)
     end
 
-    test "Rejects with 403 when revoked", %{conn: conn, user: %User{id: user_id} = user, session: %Session{} = session} do
+    test "Rejects with 403 when revoked", %{
+      conn: conn,
+      user: %User{} = _user,
+      session: %Session{} = session
+    } do
       assert is_nil(session.revoked_at)
       session = Helpers.Accounts.set_revoked(session)
       assert not is_nil(session.revoked_at)
@@ -1416,11 +1431,11 @@ defmodule MalanWeb.UserControllerTest do
       conn = get(conn, Routes.user_path(conn, :whoami))
 
       assert %{
-        "ok" => false,
-        "code" => 403,
-        "detail" => "Forbidden",
-        "message" => "API token is expired or revoked",
-        "token_expired" => true,
+               "ok" => false,
+               "code" => 403,
+               "detail" => "Forbidden",
+               "message" => "API token is expired or revoked",
+               "token_expired" => true
              } = json_response(conn, 403)
     end
   end
@@ -1452,8 +1467,7 @@ defmodule MalanWeb.UserControllerTest do
     test "Returns 404 when user is not found", %{conn: conn} do
       conn = post(conn, Routes.user_path(conn, :reset_password, "invaliduser"))
 
-      assert %{"ok" => false, "code" => 404, "detail" => "Not Found"} =
-               json_response(conn, 404)
+      assert %{"ok" => false, "code" => 404, "detail" => "Not Found"} = json_response(conn, 404)
     end
 
     test "Creates a corresponding transaction", %{conn: conn, user: %User{id: id}} do
@@ -1716,8 +1730,7 @@ defmodule MalanWeb.UserControllerTest do
           session: %{username: user.username, password: new_password}
         )
 
-      assert %{"ok" => false, "code" => 403, "detail" => "Forbidden"} =
-               json_response(conn, 403)
+      assert %{"ok" => false, "code" => 403, "detail" => "Forbidden"} = json_response(conn, 403)
 
       # Now login with the old password to make sure it still works
       conn =
@@ -1749,8 +1762,7 @@ defmodule MalanWeb.UserControllerTest do
           session: %{username: user.username, password: user.password}
         )
 
-      assert %{"ok" => false, "code" => 403, "detail" => "Forbidden"} =
-               json_response(conn, 403)
+      assert %{"ok" => false, "code" => 403, "detail" => "Forbidden"} = json_response(conn, 403)
 
       # Try to login with new password and ensure it works
       conn =
@@ -1834,8 +1846,7 @@ defmodule MalanWeb.UserControllerTest do
           session: %{username: user.username, password: new_password}
         )
 
-      assert %{"ok" => false, "code" => 403, "detail" => "Forbidden"} =
-               json_response(conn, 403)
+      assert %{"ok" => false, "code" => 403, "detail" => "Forbidden"} = json_response(conn, 403)
 
       # Now login with the old password to make sure it still works
       conn =
@@ -1888,8 +1899,7 @@ defmodule MalanWeb.UserControllerTest do
           session: %{username: user.username, password: user.password}
         )
 
-      assert %{"ok" => false, "code" => 403, "detail" => "Forbidden"} =
-               json_response(conn, 403)
+      assert %{"ok" => false, "code" => 403, "detail" => "Forbidden"} = json_response(conn, 403)
 
       # Now login with new password to make sure it works
       conn =
@@ -1912,8 +1922,7 @@ defmodule MalanWeb.UserControllerTest do
 
       # assert %{"ok" => false, "err" => "missing_password_reset_token", "msg" => _} = json_response(conn, 401)
       # For now just accept a 404
-      assert %{"ok" => false, "code" => 404, "detail" => "Not Found"} =
-               json_response(conn, 404)
+      assert %{"ok" => false, "code" => 404, "detail" => "Not Found"} = json_response(conn, 404)
     end
 
     test "Rejects when token is wrong - endpoint with no user ID", %{
@@ -1943,8 +1952,7 @@ defmodule MalanWeb.UserControllerTest do
 
       # assert %{"ok" => false, "err" => "invalid_password_reset_token", "msg" => _} = json_response(conn, 401)
       # For now just accept a 404
-      assert %{"ok" => false, "code" => 404, "detail" => "Not Found"} =
-               json_response(conn, 404)
+      assert %{"ok" => false, "code" => 404, "detail" => "Not Found"} = json_response(conn, 404)
 
       # Try to login with new password and make sure it doesn't work
       conn =
@@ -1952,8 +1960,7 @@ defmodule MalanWeb.UserControllerTest do
           session: %{username: user.username, password: new_password}
         )
 
-      assert %{"ok" => false, "code" => 403, "detail" => "Forbidden"} =
-               json_response(conn, 403)
+      assert %{"ok" => false, "code" => 403, "detail" => "Forbidden"} = json_response(conn, 403)
 
       # Try to login with old password and ensure it works
       conn =
@@ -2006,8 +2013,7 @@ defmodule MalanWeb.UserControllerTest do
           session: %{username: user.username, password: user.password}
         )
 
-      assert %{"ok" => false, "code" => 403, "detail" => "Forbidden"} =
-               json_response(conn, 403)
+      assert %{"ok" => false, "code" => 403, "detail" => "Forbidden"} = json_response(conn, 403)
 
       # Now login with new password to make sure it works
       conn =
@@ -2025,8 +2031,7 @@ defmodule MalanWeb.UserControllerTest do
 
       # assert %{"ok" => false, "err" => "missing_password_reset_token", "msg" => _} = json_response(conn, 401)
       # For now just accept a 404
-      assert %{"ok" => false, "code" => 404, "detail" => "Not Found"} =
-               json_response(conn, 404)
+      assert %{"ok" => false, "code" => 404, "detail" => "Not Found"} = json_response(conn, 404)
     end
 
     test "can't use a reset token after a new one has been created - endpoint with no user ID", %{
@@ -2079,8 +2084,7 @@ defmodule MalanWeb.UserControllerTest do
 
       # assert %{"ok" => false, "err" => "invalid_password_reset_token", "msg" => _} = json_response(conn, 401)
       # For now just accept a 404
-      assert %{"ok" => false, "code" => 404, "detail" => "Not Found"} =
-               json_response(conn, 404)
+      assert %{"ok" => false, "code" => 404, "detail" => "Not Found"} = json_response(conn, 404)
 
       # Try to login with new password and ensure it doesn't work
       conn =
@@ -2088,8 +2092,7 @@ defmodule MalanWeb.UserControllerTest do
           session: %{username: user.username, password: new_password}
         )
 
-      assert %{"ok" => false, "code" => 403, "detail" => "Forbidden"} =
-               json_response(conn, 403)
+      assert %{"ok" => false, "code" => 403, "detail" => "Forbidden"} = json_response(conn, 403)
 
       # Now login with the old password to make sure it still works
       conn =
@@ -2114,8 +2117,7 @@ defmodule MalanWeb.UserControllerTest do
           session: %{username: user.username, password: user.password}
         )
 
-      assert %{"ok" => false, "code" => 403, "detail" => "Forbidden"} =
-               json_response(conn, 403)
+      assert %{"ok" => false, "code" => 403, "detail" => "Forbidden"} = json_response(conn, 403)
 
       # Try to login with new password and ensure it works
       conn =
@@ -2589,8 +2591,7 @@ defmodule MalanWeb.UserControllerTest do
           session: %{username: user.username, password: new_password}
         )
 
-      assert %{"ok" => false, "code" => 403, "detail" => "Forbidden"} =
-               json_response(conn, 403)
+      assert %{"ok" => false, "code" => 403, "detail" => "Forbidden"} = json_response(conn, 403)
 
       # Now login with the old password to make sure it still works
       conn =
@@ -2655,8 +2656,7 @@ defmodule MalanWeb.UserControllerTest do
           session: %{username: user.username, password: user.password}
         )
 
-      assert %{"ok" => false, "code" => 403, "detail" => "Forbidden"} =
-               json_response(conn, 403)
+      assert %{"ok" => false, "code" => 403, "detail" => "Forbidden"} = json_response(conn, 403)
 
       # Now login with new password to make sure it works
       conn =
@@ -2683,8 +2683,7 @@ defmodule MalanWeb.UserControllerTest do
 
       # assert %{"ok" => false, "err" => "missing_password_reset_token", "msg" => _} = json_response(conn, 401)
       # For now just accept a 404
-      assert %{"ok" => false, "code" => 404, "detail" => "Not Found"} =
-               json_response(conn, 404)
+      assert %{"ok" => false, "code" => 404, "detail" => "Not Found"} = json_response(conn, 404)
     end
 
     test "Rejects when token is wrong - endpoint with no user ID", %{
@@ -2714,8 +2713,7 @@ defmodule MalanWeb.UserControllerTest do
 
       # assert %{"ok" => false, "err" => "invalid_password_reset_token", "msg" => _} = json_response(conn, 401)
       # For now just accept a 404
-      assert %{"ok" => false, "code" => 404, "detail" => "Not Found"} =
-               json_response(conn, 404)
+      assert %{"ok" => false, "code" => 404, "detail" => "Not Found"} = json_response(conn, 404)
 
       # Try to login with new password and make sure it doesn't work
       conn =
@@ -2723,8 +2721,7 @@ defmodule MalanWeb.UserControllerTest do
           session: %{username: user.username, password: new_password}
         )
 
-      assert %{"ok" => false, "code" => 403, "detail" => "Forbidden"} =
-               json_response(conn, 403)
+      assert %{"ok" => false, "code" => 403, "detail" => "Forbidden"} = json_response(conn, 403)
 
       # Try to login with old password and ensure it works
       conn =
@@ -2797,8 +2794,7 @@ defmodule MalanWeb.UserControllerTest do
 
       # assert %{"ok" => false, "err" => "missing_password_reset_token", "msg" => _} = json_response(conn, 401)
       # For now just accept a 404
-      assert %{"ok" => false, "code" => 404, "detail" => "Not Found"} =
-               json_response(conn, 404)
+      assert %{"ok" => false, "code" => 404, "detail" => "Not Found"} = json_response(conn, 404)
     end
 
     test "can't use a reset token after a new one has been created - endpoint with no user ID", %{
@@ -2845,8 +2841,7 @@ defmodule MalanWeb.UserControllerTest do
 
       # assert %{"ok" => false, "err" => "invalid_password_reset_token", "msg" => _} = json_response(conn, 401)
       # For now just accept a 404
-      assert %{"ok" => false, "code" => 404, "detail" => "Not Found"} =
-               json_response(conn, 404)
+      assert %{"ok" => false, "code" => 404, "detail" => "Not Found"} = json_response(conn, 404)
 
       # Try to login with new password and ensure it doesn't work
       conn =
@@ -2854,8 +2849,7 @@ defmodule MalanWeb.UserControllerTest do
           session: %{username: user.username, password: new_password}
         )
 
-      assert %{"ok" => false, "code" => 403, "detail" => "Forbidden"} =
-               json_response(conn, 403)
+      assert %{"ok" => false, "code" => 403, "detail" => "Forbidden"} = json_response(conn, 403)
 
       # Now login with the old password to make sure it still works
       conn =
@@ -2882,8 +2876,7 @@ defmodule MalanWeb.UserControllerTest do
           session: %{username: user.username, password: user.password}
         )
 
-      assert %{"ok" => false, "code" => 403, "detail" => "Forbidden"} =
-               json_response(conn, 403)
+      assert %{"ok" => false, "code" => 403, "detail" => "Forbidden"} = json_response(conn, 403)
 
       # Try to login with new password and ensure it works
       conn =
@@ -2934,8 +2927,7 @@ defmodule MalanWeb.UserControllerTest do
           session: %{username: user.username, password: new_password}
         )
 
-      assert %{"ok" => false, "code" => 403, "detail" => "Forbidden"} =
-               json_response(conn, 403)
+      assert %{"ok" => false, "code" => 403, "detail" => "Forbidden"} = json_response(conn, 403)
 
       # Now login with the old password to make sure it still works
       conn =

--- a/test/support/helpers/accounts.ex
+++ b/test/support/helpers/accounts.ex
@@ -1,6 +1,6 @@
 defmodule Malan.Test.Helpers.Accounts do
-  alias Malan.{Accounts, Repo}
-  alias Malan.Accounts.User
+  alias Malan.{Accounts, Repo, Utils}
+  alias Malan.Accounts.{User, Session}
 
   def admin_attrs() do
     ui = System.unique_integer([:positive])
@@ -243,5 +243,18 @@ defmodule Malan.Test.Helpers.Accounts do
     Enum.map(1..num_users, fn i ->
       admin_user_session_conn(conn, %{email: "admin#{i}@email.com", username: "adminuser#{i}"})
     end)
+  end
+
+  def set_expired(session) do
+    session
+    |> set_expires_at(Utils.DateTime.adjust_cur_time(-10, :seconds))
+  end
+
+  def set_expires_at(session, expires_at) do
+    {:ok, session} = session
+    |> Session.admin_changeset(%{expires_at: expires_at})
+    |> Repo.update()
+
+    session
   end
 end

--- a/test/support/helpers/accounts.ex
+++ b/test/support/helpers/accounts.ex
@@ -257,4 +257,14 @@ defmodule Malan.Test.Helpers.Accounts do
 
     session
   end
+
+  def set_revoked(session) do
+    session
+    |> set_revoked_at(Utils.DateTime.adjust_cur_time(-10, :seconds))
+  end
+
+  def set_revoked_at(session, revoked_at) do
+    {:ok, session} = Accounts.revoke_session(session)
+    session
+  end
 end


### PR DESCRIPTION
Add curl script for testing token expiration

Cleanup some warnings and apply formatting fixes

Fix return code in User whoami endpoint
    
whoami endpoint returned 404 when a token was expired or revoked, which is not ideal.  We accepted it as a bug before but now we want to add user experience for logging in after a session expires, so this needed to be fixed.
    
Fixes #101

Fix small bug in auth error reporting and add more test coverage

Add token_expired to 403 when token is expired
    
If the token is expired (or revoked) there will be a property "token_expired" in the 403 return body.
    
Fixes #102