### PR TITLE
Add escape hatch for tls in prod

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -1,5 +1,7 @@
 import Config
 
+alias Malan.Utils
+
 # config/runtime.exs is executed for all environments, including
 # during releases. It is executed after compilation and before the
 # system starts, so it is typically used to load production configuration
@@ -8,6 +10,7 @@ import Config
 # The block below contains prod specific runtime configuration.
 
 # Start the phoenix server if environment is set and running in a release
+
 if System.get_env("PHX_SERVER") && System.get_env("RELEASE_NAME") do
   config :malan, MalanWeb.Endpoint, server: true
 end
@@ -27,10 +30,10 @@ if config_env() == :prod do
     url: database_url,
     pool_size: String.to_integer(System.get_env("POOL_SIZE") || "10"),
     socket_options: maybe_ipv6,
-    ssl: true,
+    ssl: System.get_env("DATABASE_TLS_ENABLED") |> Utils.true_or_explicitly_false?(),
     ssl_opts: [
       # To verify provider's self-signed cert
-      cacertfile: "priv/certs/do-db-ca-cert.crt",
+      cacertfile: "priv/certs/do-db-ca-cert.crt"
 
       # To provide mTLS client creds
       # keyfile: "priv/client-key.pem",
@@ -84,5 +87,4 @@ if config_env() == :prod do
   config :swoosh, :api_client, Swoosh.ApiClient.Hackney
 
   config :sentry, dsn: System.get_env("SENTRY_DSN")
-
 end

--- a/lib/malan/accounts.ex
+++ b/lib/malan/accounts.ex
@@ -1022,7 +1022,7 @@ defmodule Malan.Accounts do
 
   def session_revoked?(revoked_at), do: !!revoked_at
 
-  def session_expired?(%Session{expires_at: expires_at} = session),
+  def session_expired?(%Session{expires_at: expires_at}),
     do: session_expired?(expires_at)
 
   def session_expired?(expires_at),

--- a/lib/malan/utils.ex
+++ b/lib/malan/utils.ex
@@ -423,6 +423,41 @@ defmodule Malan.Utils do
   end
 
   def trunc_str(str, length \\ 255), do: String.slice(str, 0, length)
+
+  @doc ~S"""
+  If `val` is explicitly (and therefore unambiguously) true, then returns `false`.  Otherwise `true`
+
+  Explicitly true values are case-insensitive, "t", "true", "yes", "y"
+  """
+  def explicitly_true?(val) when is_binary(val), do: String.downcase(val) in ~w[t true yes y]
+
+  @doc ~S"""
+  If `val` is explicitly (and therefore unambiguously) false, then returns `true`.  Otherwise `false`
+
+  Explicitly false values are case-insensitive, "f", "false", "no", "n"
+  """
+  def explicitly_false?(val) when is_binary(val), do: String.downcase(val) in ~w[f false no n]
+
+  @doc ~S"""
+  If `val` is explicitly true, output is true.  Otherwise false
+
+  The effect of this is that if the string isn't explicitly true then it is
+  considered false.  This is useful for example with an env var where the default
+  should be `false`
+  """
+  def false_or_explicitly_true?(val) when is_binary(val), do: explicitly_true?(val)
+  def false_or_explicitly_true?(val) when is_atom(val), do: val == true
+
+  @doc ~S"""
+  If `val` is explicitly false, output is false.  Otherwise true
+
+  The effect of this is that if the string isn't explicitly false then it is
+  considered true.  This is useful for example with an env var where the default
+  should be `true`
+  """
+  def true_or_explicitly_false?(val) when is_binary(val), do: not explicitly_false?(val)
+  def true_or_explicitly_false?(nil), do: true
+  def true_or_explicitly_false?(val) when is_atom(val), do: !!val
 end
 
 defmodule Malan.Utils.Enum do

--- a/test/malan/utils_test.exs
+++ b/test/malan/utils_test.exs
@@ -213,6 +213,107 @@ defmodule Malan.UtilsTest do
 
       assert after_removed == Utils.remove_not_loaded(before)
     end
+
+    test "#explicitly_true?/1" do
+      assert true == Utils.explicitly_true?("true")
+      assert true == Utils.explicitly_true?("True")
+      assert true == Utils.explicitly_true?("T")
+      assert true == Utils.explicitly_true?("t")
+      assert true == Utils.explicitly_true?("Yes")
+      assert true == Utils.explicitly_true?("yes")
+      assert true == Utils.explicitly_true?("Y")
+      assert true == Utils.explicitly_true?("y")
+
+      assert false == Utils.explicitly_true?("F")
+      assert false == Utils.explicitly_true?("f")
+      assert false == Utils.explicitly_true?("False")
+      assert false == Utils.explicitly_true?("false")
+      assert false == Utils.explicitly_true?("n")
+      assert false == Utils.explicitly_true?("N")
+      assert false == Utils.explicitly_true?("no")
+      assert false == Utils.explicitly_true?("No")
+      assert false == Utils.explicitly_true?("NO")
+      assert false == Utils.explicitly_true?("nO")
+    end
+
+    test "#false_or_explicitly_true?/1" do
+      assert false == Utils.false_or_explicitly_true?("F")
+      assert false == Utils.false_or_explicitly_true?("f")
+      assert false == Utils.false_or_explicitly_true?("False")
+      assert false == Utils.false_or_explicitly_true?("false")
+      assert false == Utils.false_or_explicitly_true?("n")
+      assert false == Utils.false_or_explicitly_true?("N")
+      assert false == Utils.false_or_explicitly_true?("no")
+      assert false == Utils.false_or_explicitly_true?("No")
+      assert false == Utils.false_or_explicitly_true?("NO")
+      assert false == Utils.false_or_explicitly_true?("nO")
+
+      assert false == Utils.false_or_explicitly_true?(false)
+      assert false == Utils.false_or_explicitly_true?("Hello")
+      assert false == Utils.false_or_explicitly_true?("")
+      assert false == Utils.false_or_explicitly_true?(nil)
+
+      assert true == Utils.false_or_explicitly_true?("true")
+      assert true == Utils.false_or_explicitly_true?("True")
+      assert true == Utils.false_or_explicitly_true?("T")
+      assert true == Utils.false_or_explicitly_true?("t")
+      assert true == Utils.false_or_explicitly_true?("Yes")
+      assert true == Utils.false_or_explicitly_true?("yes")
+      assert true == Utils.false_or_explicitly_true?("Y")
+      assert true == Utils.false_or_explicitly_true?("y")
+      assert true == Utils.false_or_explicitly_true?(true)
+    end
+
+    test "#explicitly_false?/1" do
+      assert false == Utils.explicitly_false?("true")
+      assert false == Utils.explicitly_false?("True")
+      assert false == Utils.explicitly_false?("T")
+      assert false == Utils.explicitly_false?("t")
+      assert false == Utils.explicitly_false?("Yes")
+      assert false == Utils.explicitly_false?("yes")
+      assert false == Utils.explicitly_false?("Y")
+      assert false == Utils.explicitly_false?("y")
+
+      assert true == Utils.explicitly_false?("F")
+      assert true == Utils.explicitly_false?("f")
+      assert true == Utils.explicitly_false?("False")
+      assert true == Utils.explicitly_false?("false")
+      assert true == Utils.explicitly_false?("n")
+      assert true == Utils.explicitly_false?("N")
+      assert true == Utils.explicitly_false?("no")
+      assert true == Utils.explicitly_false?("No")
+      assert true == Utils.explicitly_false?("NO")
+      assert true == Utils.explicitly_false?("nO")
+    end
+
+    test "#true_or_explicitly_false?/1" do
+      assert false == Utils.true_or_explicitly_false?("F")
+      assert false == Utils.true_or_explicitly_false?("f")
+      assert false == Utils.true_or_explicitly_false?("False")
+      assert false == Utils.true_or_explicitly_false?("false")
+      assert false == Utils.true_or_explicitly_false?("n")
+      assert false == Utils.true_or_explicitly_false?("N")
+      assert false == Utils.true_or_explicitly_false?("no")
+      assert false == Utils.true_or_explicitly_false?("No")
+      assert false == Utils.true_or_explicitly_false?("NO")
+      assert false == Utils.true_or_explicitly_false?("nO")
+
+      assert false == Utils.true_or_explicitly_false?(false)
+
+      assert true == Utils.true_or_explicitly_false?("true")
+      assert true == Utils.true_or_explicitly_false?("True")
+      assert true == Utils.true_or_explicitly_false?("T")
+      assert true == Utils.true_or_explicitly_false?("t")
+      assert true == Utils.true_or_explicitly_false?("Yes")
+      assert true == Utils.true_or_explicitly_false?("yes")
+      assert true == Utils.true_or_explicitly_false?("Y")
+      assert true == Utils.true_or_explicitly_false?("y")
+
+      assert true == Utils.true_or_explicitly_false?(true)
+      assert true == Utils.true_or_explicitly_false?("Hello")
+      assert true == Utils.true_or_explicitly_false?("")
+      assert true == Utils.true_or_explicitly_false?(nil)
+    end
   end
 
   describe "Crypto" do


### PR DESCRIPTION
Add env var to disable TLS in release mode

When running malan locally, sometimes we use the production/release
build.  In that situation we often don't have TLS set up locally, so
wish to disable it. 

This adds an env var "DATABASE_TLS_ENABLED" which can be explicitly set 
to false in order to disable TLS.  If absent, the default is true
(require TLS)

Add Utils functions for explicitly true/false

When converting a string to a boolean, we need a default.  These
functions provide a default

