### PR TITLE
Change birthday type in schema to date rather than datetime

### DIFF
--- a/lib/malan/accounts/user.ex
+++ b/lib/malan/accounts/user.ex
@@ -35,7 +35,7 @@ defmodule Malan.Accounts.User do
     field :deleted_at, :utc_datetime
     field :latest_tos_accept_ver, :integer # nil means rejected
     field :latest_pp_accept_ver, :integer  # nil means rejected
-    field :birthday, :utc_datetime         # nil means not specified
+    field :birthday, :date                 # nil means not specified
     field :weight, :decimal                # nil means not specified
     field :height, :decimal                # nil means not specified
     field :race_enum, {:array, :integer}   # nil means not specified

--- a/livebooks/query_birthdays.exs
+++ b/livebooks/query_birthdays.exs
@@ -13,3 +13,5 @@ from(u in User, where: not is_nil(u.birthday), limit: 10)
 from(u in User, select: count(u.id), where: not is_nil(u.birthday))
 |> Repo.one()
 
+from(u in User, select: {u.id, u.email, u.birthday}, where: not is_nil(u.birthday), limit: 10)
+|> Repo.all()

--- a/priv/repo/migrations/20220510231539_change_birthday_to_date.exs
+++ b/priv/repo/migrations/20220510231539_change_birthday_to_date.exs
@@ -1,0 +1,9 @@
+defmodule Malan.Repo.Migrations.ChangeBirthdayToDate do
+  use Ecto.Migration
+
+  def change do
+    alter table("users") do
+      modify :birthday, :date, from: :utc_datetime
+    end
+  end
+end

--- a/test/malan_web/controllers/user_controller_test.exs
+++ b/test/malan_web/controllers/user_controller_test.exs
@@ -708,7 +708,7 @@ defmodule MalanWeb.UserControllerTest do
         accept_privacy_policy: true,
         preferences: %{theme: "dark"},
         sex: "male",
-        birthday: ~U[1986-06-13 01:09:08.105179Z],
+        birthday: ~D[1986-06-13],
         roles: ["admin", "user"],  # Shouldn't make it through
         custom_attrs: %{
           "hereiam" => "rockyou",
@@ -725,7 +725,7 @@ defmodule MalanWeb.UserControllerTest do
                  "email_verified" => nil,
                  "preferences" => %{"theme" => "dark"},
                  "roles" => ["user"],
-                 "birthday" => "1986-06-13T01:09:08Z",
+                 "birthday" => "1986-06-13",
                  "sex" => "Male",
                  "gender" => nil,
                  "latest_tos_accept_ver" => 1,

--- a/test/malan_web/controllers/user_controller_test.exs
+++ b/test/malan_web/controllers/user_controller_test.exs
@@ -19,7 +19,8 @@ defmodule MalanWeb.UserControllerTest do
     first_name: "Some",
     last_name: "cool User",
     custom_attrs: %{"hereiam" => "rockyou", "likea" => "hurricane", "year" => 1986},
-    locked_at: "",  # Shouldn't make it through
+    birthday: "1986-06-13",
+    locked_at: ""  # Shouldn't make it through
   }
   @invalid_attrs %{
     email: nil,
@@ -1072,6 +1073,69 @@ defmodule MalanWeb.UserControllerTest do
       assert [tx] == Accounts.list_transactions_by_user_id(id, 0, 10)
       assert [tx] == Accounts.list_transactions_by_session_id(session_id, 0, 10)
       assert [tx] == Accounts.list_transactions_by_who(id, 0, 10)
+    end
+
+    test "Accepts datetimes and more precision on birthday", %{conn: conn, user: %User{} = user} do
+      email = user.email
+
+      {:ok, session} = Helpers.Accounts.create_session(user)
+      conn = Helpers.Accounts.put_token(conn, session.api_token)
+
+      [
+        "2022-05-11 01:30:49.970337Z",
+        "2022-05-11 01:30:49.00000",
+        "2022-05-11 01:30:49.00",
+        "2022-05-11 01:30:49",
+        "2022-05-11"
+      ]
+      |> Enum.each(fn datetime ->
+        conn = put(conn, Routes.user_path(conn, :update, user), user: %{birthday: datetime})
+
+        assert %{"id" => id} = json_response(conn, 200)["data"]
+
+        conn = get(conn, Routes.user_path(conn, :show, id))
+
+        assert %{
+                 # "ok" => true,
+                 # "code" => 200,
+                 "data" => %{
+                   "id" => ^id,
+                   "email" => ^email,
+                   "birthday" => "2022-05-11"
+                 }
+               } = json_response(conn, 200)
+      end)
+    end
+
+    test "Rejects malformed birthdays", %{conn: conn, user: %User{} = user} do
+      {:ok, session} = Helpers.Accounts.create_session(user)
+      conn = Helpers.Accounts.put_token(conn, session.api_token)
+
+      [
+        "2022-05-11 01:30",
+        "2022-05-11 01",
+        "2022-05",
+        "false",
+        "4.567",
+        "2022",
+        "null",
+        "abc",
+        "nil"
+      ]
+      |> Enum.each(fn datetime ->
+        conn = put(conn, Routes.user_path(conn, :update, user), user: %{birthday: datetime})
+
+        assert %{
+                 "ok" => false,
+                 "code" => 422,
+                 "detail" => "Unprocessable Entity",
+                 "message" =>
+                   "The request was syntactically correct, but some or all of the parameters failed validation.  See errors key for details",
+                 "errors" => %{
+                   "birthday" => ["is invalid"]
+                 }
+               } = json_response(conn, 422)
+      end)
     end
   end
 


### PR DESCRIPTION
The original idea was that "birth" can occur at specific times,
so a datetime was a good type. However in practice that extra
precision can complicate things when timezones come into play.
To avoid this problem, it would be best to have birthday be a
date instead of a datetime

Note:  For actually changing the data in postgres, this migration relies
on postgres automatic date conversion.  It was tested with a broad range
of datetimes, and each time the hours/minutes/seconds portion was
dropped and the date itself was kept by postgres.

Fixes #107