### PR TITLE
Return ok true users sessions

### DIFF
--- a/lib/malan_web/controllers/session_controller.ex
+++ b/lib/malan_web/controllers/session_controller.ex
@@ -20,7 +20,13 @@ defmodule MalanWeb.SessionController do
   def admin_index(conn, _params) do
     {page_num, page_size} = pagination_info(conn)
     sessions = Accounts.list_sessions(page_num, page_size)
-    render(conn, "index.json", code: 200, sessions: sessions, page_num: page_num, page_size: page_size)
+
+    render(conn, "index.json",
+      code: 200,
+      sessions: sessions,
+      page_num: page_num,
+      page_size: page_size
+    )
   end
 
   def admin_delete(conn, %{"id" => id}) do
@@ -62,7 +68,13 @@ defmodule MalanWeb.SessionController do
   def index(conn, %{"user_id" => user_id}) do
     {page_num, page_size} = pagination_info(conn)
     sessions = Accounts.list_sessions(user_id, page_num, page_size)
-    render(conn, "index.json", code: 200, sessions: sessions, page_num: page_num, page_size: page_size)
+
+    render(conn, "index.json",
+      code: 200,
+      sessions: sessions,
+      page_num: page_num,
+      page_size: page_size
+    )
   end
 
   def index_active(conn, params) do
@@ -75,7 +87,13 @@ defmodule MalanWeb.SessionController do
   def user_index_active(conn, %{"user_id" => user_id}) do
     {page_num, page_size} = pagination_info(conn)
     sessions = Accounts.list_active_sessions(user_id, page_num, page_size)
-    render(conn, "index.json", code: 200, sessions: sessions, page_num: page_num, page_size: page_size)
+
+    render(conn, "index.json",
+      code: 200,
+      sessions: sessions,
+      page_num: page_num,
+      page_size: page_size
+    )
   end
 
   def create(conn, %{
@@ -220,6 +238,7 @@ defmodule MalanWeb.SessionController do
   defp put_ip_addr(session_params, conn) do
     session_params
     |> Map.put("ip_address", Utils.IPv4.to_s(conn))
+
     # |> Map.put("real_ip_address", get_cf_real_ip_addr(conn))
   end
 end

--- a/lib/malan_web/controllers/session_controller.ex
+++ b/lib/malan_web/controllers/session_controller.ex
@@ -20,7 +20,7 @@ defmodule MalanWeb.SessionController do
   def admin_index(conn, _params) do
     {page_num, page_size} = pagination_info(conn)
     sessions = Accounts.list_sessions(page_num, page_size)
-    render(conn, "index.json", sessions: sessions, page_num: page_num, page_size: page_size)
+    render(conn, "index.json", code: 200, sessions: sessions, page_num: page_num, page_size: page_size)
   end
 
   def admin_delete(conn, %{"id" => id}) do
@@ -41,7 +41,7 @@ defmodule MalanWeb.SessionController do
         tx_changeset
       )
 
-      render(conn, "show.json", session: session)
+      render(conn, "show.json", code: 200, session: session)
     else
       {:error, err_cs} ->
         err_str = Utils.Ecto.Changeset.errors_to_str(err_cs)
@@ -62,7 +62,7 @@ defmodule MalanWeb.SessionController do
   def index(conn, %{"user_id" => user_id}) do
     {page_num, page_size} = pagination_info(conn)
     sessions = Accounts.list_sessions(user_id, page_num, page_size)
-    render(conn, "index.json", sessions: sessions, page_num: page_num, page_size: page_size)
+    render(conn, "index.json", code: 200, sessions: sessions, page_num: page_num, page_size: page_size)
   end
 
   def index_active(conn, params) do
@@ -75,7 +75,7 @@ defmodule MalanWeb.SessionController do
   def user_index_active(conn, %{"user_id" => user_id}) do
     {page_num, page_size} = pagination_info(conn)
     sessions = Accounts.list_active_sessions(user_id, page_num, page_size)
-    render(conn, "index.json", sessions: sessions, page_num: page_num, page_size: page_size)
+    render(conn, "index.json", code: 200, sessions: sessions, page_num: page_num, page_size: page_size)
   end
 
   def create(conn, %{
@@ -101,7 +101,7 @@ defmodule MalanWeb.SessionController do
 
       conn
       |> put_status(:created)
-      |> render("show.json", session: session)
+      |> render("show.json", code: 201, session: session)
     else
       # Logging of failed login attemps (aka session creation) currently happens
       # in accounts.ex
@@ -123,7 +123,7 @@ defmodule MalanWeb.SessionController do
 
   def show(conn, %{"id" => id}) do
     session = Accounts.get_session!(id)
-    render(conn, "show.json", session: session)
+    render(conn, "show.json", code: 200, session: session)
   end
 
   def show_current(conn, %{}), do: show(conn, %{"id" => conn.assigns.authed_session_id})
@@ -146,7 +146,7 @@ defmodule MalanWeb.SessionController do
         changeset
       )
 
-      render(conn, "show.json", session: session)
+      render(conn, "show.json", code: 200, session: session)
     else
       {:error, err} ->
         err_str = Utils.Ecto.Changeset.errors_to_str(err)
@@ -172,7 +172,7 @@ defmodule MalanWeb.SessionController do
         num_revoked: num_revoked
       })
 
-      render(conn, "delete_all.json", num_revoked: num_revoked)
+      render(conn, "delete_all.json", code: 200, num_revoked: num_revoked)
     else
       {:error, err} ->
         err_str = Utils.Ecto.Changeset.errors_to_str(err)

--- a/lib/malan_web/controllers/user_controller.ex
+++ b/lib/malan_web/controllers/user_controller.ex
@@ -34,7 +34,7 @@ defmodule MalanWeb.UserController do
   def index(conn, _params) do
     {page_num, page_size} = pagination_info(conn)
     users = Accounts.list_users(page_num, page_size)
-    render(conn, "index.json", users: users, page_num: page_num, page_size: page_size)
+    render(conn, "index.json", code: 200, users: users, page_num: page_num, page_size: page_size)
   end
 
   def create(conn, %{"user" => user_params}) do
@@ -47,7 +47,7 @@ defmodule MalanWeb.UserController do
       |> record_transaction(true, id, username, "POST", "#UserController.create/2", changeset)
       |> put_status(:created)
       |> put_resp_header("location", Routes.user_path(conn, :show, user))
-      |> render("show.json", user: user)
+      |> render("show.json", code: 201, user: user)
     else
       {:error, err} ->
         err_str = Utils.Ecto.Changeset.errors_to_str(err)
@@ -99,7 +99,7 @@ defmodule MalanWeb.UserController do
           changeset
         )
 
-        render(conn, "show.json", user: user)
+        render(conn, "show.json", code: 200, user: user)
       else
         {:error, err} ->
           err_str = Utils.Ecto.Changeset.errors_to_str(err)
@@ -138,7 +138,7 @@ defmodule MalanWeb.UserController do
           changeset
         )
 
-        render(conn, "show.json", user: user)
+        render(conn, "show.json", code: 200, user: user)
       else
         {:error, err} ->
           err_str = Utils.Ecto.Changeset.errors_to_str(err)
@@ -177,7 +177,7 @@ defmodule MalanWeb.UserController do
           changeset
         )
 
-        render(conn, "show.json", user: user)
+        render(conn, "show.json", code: 200, user: user)
       else
         {:error, %Ecto.Changeset{} = cs} ->
           err_str = Utils.Ecto.Changeset.errors_to_str(cs)
@@ -229,7 +229,7 @@ defmodule MalanWeb.UserController do
           changeset
         )
 
-        render(conn, "show.json", user: user)
+        render(conn, "show.json", code: 200, user: user)
       else
         {:error, err} ->
           err_str = Utils.Ecto.Changeset.errors_to_str(err)
@@ -338,7 +338,7 @@ defmodule MalanWeb.UserController do
 
         conn
         |> put_status(200)
-        |> json(%{ok: true})
+        |> json(%{ok: true, code: 200})
       else
         # {:error, :too_many_requests}
         # {:error, changeset}
@@ -466,7 +466,7 @@ defmodule MalanWeb.UserController do
 
       conn
       |> put_status(200)
-      |> json(%{ok: true})
+      |> json(%{ok: true, code: 200})
     else
       {:error, :missing_password_reset_token = err} ->
         conn
@@ -474,6 +474,7 @@ defmodule MalanWeb.UserController do
         |> put_status(401)
         |> json(%{
           ok: false,
+          code: 401,
           err: err,
           msg: "No password reset token has been issued"
         })
@@ -484,6 +485,7 @@ defmodule MalanWeb.UserController do
         |> put_status(401)
         |> json(%{
           ok: false,
+          code: 401,
           err: err,
           msg: "Password reset token in invalid"
         })
@@ -494,6 +496,7 @@ defmodule MalanWeb.UserController do
         |> put_status(401)
         |> json(%{
           ok: false,
+          code: 401,
           err: err,
           msg: "Password reset token is expired"
         })
@@ -547,6 +550,7 @@ defmodule MalanWeb.UserController do
     render(
       conn,
       "whoami.json",
+      code: 200,
       user_id: user_id,
       session_id: session_id,
       user_roles: user_roles,
@@ -565,7 +569,7 @@ defmodule MalanWeb.UserController do
       |> put_view(MalanWeb.ErrorView)
       |> render(:"404")
     else
-      render(conn, "show.json", user: user)
+      render(conn, "show.json", code: 200, user: user)
     end
   end
 
@@ -573,6 +577,7 @@ defmodule MalanWeb.UserController do
     render(
       conn,
       "password_reset.json",
+      code: 200,
       password_reset_token: user.password_reset_token,
       password_reset_token_expires_at: user.password_reset_token_expires_at
     )

--- a/lib/malan_web/views/address_view.ex
+++ b/lib/malan_web/views/address_view.ex
@@ -3,11 +3,11 @@ defmodule MalanWeb.AddressView do
   alias MalanWeb.AddressView
 
   def render("index.json", %{addresses: addresses}) do
-    %{data: render_many(addresses, AddressView, "address.json")}
+    %{ok: true, data: render_many(addresses, AddressView, "address.json")}
   end
 
   def render("show.json", %{address: address}) do
-    %{data: render_one(address, AddressView, "address.json")}
+    %{ok: true, data: render_one(address, AddressView, "address.json")}
   end
 
   def render("address.json", %{address: address}) do

--- a/lib/malan_web/views/phone_number_view.ex
+++ b/lib/malan_web/views/phone_number_view.ex
@@ -3,11 +3,11 @@ defmodule MalanWeb.PhoneNumberView do
   alias MalanWeb.PhoneNumberView
 
   def render("index.json", %{phone_numbers: phone_numbers}) do
-    %{data: render_many(phone_numbers, PhoneNumberView, "phone_number.json")}
+    %{ok: true, data: render_many(phone_numbers, PhoneNumberView, "phone_number.json")}
   end
 
   def render("show.json", %{phone_number: phone_number}) do
-    %{data: render_one(phone_number, PhoneNumberView, "phone_number.json")}
+    %{ok: true, data: render_one(phone_number, PhoneNumberView, "phone_number.json")}
   end
 
   def render("phone_number.json", %{phone_number: phone_number}) do

--- a/lib/malan_web/views/session_view.ex
+++ b/lib/malan_web/views/session_view.ex
@@ -6,11 +6,11 @@ defmodule MalanWeb.SessionView do
   alias MalanWeb.SessionView
 
   def render("index.json", %{sessions: sessions}) do
-    %{data: render_many(sessions, SessionView, "session.json")}
+    %{ok: true, data: render_many(sessions, SessionView, "session.json")}
   end
 
   def render("show.json", %{session: session}) do
-    %{data: render_one(session, SessionView, "session.json")}
+    %{ok: true, data: render_one(session, SessionView, "session.json")}
   end
 
   def render("session.json", %{session: session}) do
@@ -33,6 +33,7 @@ defmodule MalanWeb.SessionView do
 
   def render("delete_all.json", %{num_revoked: num_revoked}) do
     %{
+      ok: true,
       data: %{
         status: true,
         num_revoked: num_revoked,

--- a/lib/malan_web/views/session_view.ex
+++ b/lib/malan_web/views/session_view.ex
@@ -5,12 +5,12 @@ defmodule MalanWeb.SessionView do
 
   alias MalanWeb.SessionView
 
-  def render("index.json", %{sessions: sessions}) do
-    %{ok: true, data: render_many(sessions, SessionView, "session.json")}
+  def render("index.json", %{code: code, sessions: sessions}) do
+    %{ok: true, code: code, data: render_many(sessions, SessionView, "session.json")}
   end
 
-  def render("show.json", %{session: session}) do
-    %{ok: true, data: render_one(session, SessionView, "session.json")}
+  def render("show.json", %{code: code, session: session}) do
+    %{ok: true, code: code, data: render_one(session, SessionView, "session.json")}
   end
 
   def render("session.json", %{session: session}) do
@@ -31,9 +31,10 @@ defmodule MalanWeb.SessionView do
     |> Enum.into(%{})
   end
 
-  def render("delete_all.json", %{num_revoked: num_revoked}) do
+  def render("delete_all.json", %{code: code, num_revoked: num_revoked}) do
     %{
       ok: true,
+      code: code,
       data: %{
         status: true,
         num_revoked: num_revoked,

--- a/lib/malan_web/views/transaction_view.ex
+++ b/lib/malan_web/views/transaction_view.ex
@@ -5,11 +5,11 @@ defmodule MalanWeb.TransactionView do
   alias MalanWeb.TransactionView
 
   def render("index.json", %{transactions: transactions}) do
-    %{data: render_many(transactions, TransactionView, "transaction.json")}
+    %{ok: true, data: render_many(transactions, TransactionView, "transaction.json")}
   end
 
   def render("show.json", %{transaction: transaction}) do
-    %{data: render_one(transaction, TransactionView, "transaction.json")}
+    %{ok: true, data: render_one(transaction, TransactionView, "transaction.json")}
   end
 
   def render("transaction.json", %{transaction: transaction}) do

--- a/lib/malan_web/views/user_view.ex
+++ b/lib/malan_web/views/user_view.ex
@@ -11,20 +11,25 @@ defmodule MalanWeb.UserView do
   alias MalanWeb.PhoneNumberView
 
   def render("index.json", %{users: users, page_num: page_num, page_size: page_size}) do
-    %{data: render_many(users, UserView, "user.json"), page_num: page_num, page_size: page_size}
+    %{
+      ok: true,
+      data: render_many(users, UserView, "user.json"),
+      page_num: page_num,
+      page_size: page_size
+    }
   end
 
   def render("show.json", %{user: %User{addresses: %Ecto.Association.NotLoaded{}} = user}) do
-    %{data: render_one(user, UserView, "user.json")}
+    %{ok: true, data: render_one(user, UserView, "user.json")}
   end
 
   def render("show.json", %{user: %User{phone_numbers: %Ecto.Association.NotLoaded{}} = user}) do
-    %{data: render_one(user, UserView, "user.json")}
+    %{ok: true, data: render_one(user, UserView, "user.json")}
   end
 
   # def render("show.json", %{user: %User{phone_numbers: _} = user}) do
   def render("show.json", %{user: %User{} = user}) do
-    %{data: render_one(user, UserView, "user_full.json")}
+    %{ok: true, data: render_one(user, UserView, "user_full.json")}
   end
 
   # def render("show.json", %{user: user}) do
@@ -94,6 +99,7 @@ defmodule MalanWeb.UserView do
         pp: pp
       }) do
     %{
+      ok: true,
       data: %{
         user_id: user_id,
         session_id: session_id,
@@ -112,6 +118,7 @@ defmodule MalanWeb.UserView do
         password_reset_token_expires_at: password_reset_token_expires_at
       }) do
     %{
+      ok: true,
       data: %{
         password_reset_token: password_reset_token,
         password_reset_token_expires_at: password_reset_token_expires_at

--- a/lib/malan_web/views/user_view.ex
+++ b/lib/malan_web/views/user_view.ex
@@ -20,11 +20,17 @@ defmodule MalanWeb.UserView do
     }
   end
 
-  def render("show.json", %{code: code, user: %User{addresses: %Ecto.Association.NotLoaded{}} = user}) do
+  def render("show.json", %{
+        code: code,
+        user: %User{addresses: %Ecto.Association.NotLoaded{}} = user
+      }) do
     %{ok: true, code: code, data: render_one(user, UserView, "user.json")}
   end
 
-  def render("show.json", %{code: code, user: %User{phone_numbers: %Ecto.Association.NotLoaded{}} = user}) do
+  def render("show.json", %{
+        code: code,
+        user: %User{phone_numbers: %Ecto.Association.NotLoaded{}} = user
+      }) do
     %{ok: true, code: code, data: render_one(user, UserView, "user.json")}
   end
 

--- a/lib/malan_web/views/user_view.ex
+++ b/lib/malan_web/views/user_view.ex
@@ -10,26 +10,27 @@ defmodule MalanWeb.UserView do
   alias MalanWeb.AddressView
   alias MalanWeb.PhoneNumberView
 
-  def render("index.json", %{users: users, page_num: page_num, page_size: page_size}) do
+  def render("index.json", %{code: code, users: users, page_num: page_num, page_size: page_size}) do
     %{
       ok: true,
+      code: code,
       data: render_many(users, UserView, "user.json"),
       page_num: page_num,
       page_size: page_size
     }
   end
 
-  def render("show.json", %{user: %User{addresses: %Ecto.Association.NotLoaded{}} = user}) do
-    %{ok: true, data: render_one(user, UserView, "user.json")}
+  def render("show.json", %{code: code, user: %User{addresses: %Ecto.Association.NotLoaded{}} = user}) do
+    %{ok: true, code: code, data: render_one(user, UserView, "user.json")}
   end
 
-  def render("show.json", %{user: %User{phone_numbers: %Ecto.Association.NotLoaded{}} = user}) do
-    %{ok: true, data: render_one(user, UserView, "user.json")}
+  def render("show.json", %{code: code, user: %User{phone_numbers: %Ecto.Association.NotLoaded{}} = user}) do
+    %{ok: true, code: code, data: render_one(user, UserView, "user.json")}
   end
 
   # def render("show.json", %{user: %User{phone_numbers: _} = user}) do
-  def render("show.json", %{user: %User{} = user}) do
-    %{ok: true, data: render_one(user, UserView, "user_full.json")}
+  def render("show.json", %{code: code, user: %User{} = user}) do
+    %{ok: true, code: code, data: render_one(user, UserView, "user_full.json")}
   end
 
   # def render("show.json", %{user: user}) do
@@ -89,6 +90,7 @@ defmodule MalanWeb.UserView do
   end
 
   def render("whoami.json", %{
+        code: code,
         user_id: user_id,
         session_id: session_id,
         ip_address: ip_address,
@@ -100,6 +102,7 @@ defmodule MalanWeb.UserView do
       }) do
     %{
       ok: true,
+      code: code,
       data: %{
         user_id: user_id,
         session_id: session_id,
@@ -114,11 +117,13 @@ defmodule MalanWeb.UserView do
   end
 
   def render("password_reset.json", %{
+        code: code,
         password_reset_token: password_reset_token,
         password_reset_token_expires_at: password_reset_token_expires_at
       }) do
     %{
       ok: true,
+      code: code,
       data: %{
         password_reset_token: password_reset_token,
         password_reset_token_expires_at: password_reset_token_expires_at

--- a/test/malan_web/controllers/session_controller_test.exs
+++ b/test/malan_web/controllers/session_controller_test.exs
@@ -50,21 +50,23 @@ defmodule MalanWeb.SessionControllerTest do
       {:ok, _au, as} = Helpers.Accounts.admin_user_with_session()
 
       conn = get(conn, Routes.session_path(conn, :admin_index))
+
       assert %{
-        "ok" => false,
-        "code" => 403,
-        "detail" => "Forbidden",
-        "message" => _
-      } = json_response(conn, 403)
+               "ok" => false,
+               "code" => 403,
+               "detail" => "Forbidden",
+               "message" => _
+             } = json_response(conn, 403)
 
       conn = Helpers.Accounts.put_token(build_conn(), rs1.api_token)
       conn = get(conn, Routes.session_path(conn, :admin_index))
+
       assert %{
-        "ok" => false,
-        "code" => 401,
-        "detail" => "Unauthorized",
-        "message" => _
-      } = json_response(conn, 401)
+               "ok" => false,
+               "code" => 401,
+               "detail" => "Unauthorized",
+               "message" => _
+             } = json_response(conn, 401)
 
       # When ToS and Privay Policy are required, uncomment the below
       conn = Helpers.Accounts.put_token(build_conn(), as.api_token)
@@ -89,11 +91,13 @@ defmodule MalanWeb.SessionControllerTest do
       ## Accept Privacy Policy
       # {:ok, _au} = Helpers.Accounts.accept_user_pp(au, true)
       conn = get(conn, Routes.session_path(conn, :admin_index))
+
       assert %{
-        "ok" => true,
-        "code" => 200,
-        "data" => data
-      } = json_response(conn, 200)
+               "ok" => true,
+               "code" => 200,
+               "data" => data
+             } = json_response(conn, 200)
+
       assert length(data) == 4
       assert true == Enum.any?(data, fn s -> s["id"] == as.id end)
       assert true == Enum.any?(data, fn s -> s["id"] == rs1.id end)
@@ -101,12 +105,13 @@ defmodule MalanWeb.SessionControllerTest do
 
     test "Requires being authenticated", %{conn: conn} do
       conn = get(conn, Routes.session_path(conn, :admin_index))
+
       assert %{
-        "ok" => false,
-        "code" => 403,
-        "detail" => "Forbidden",
-        "message" => _
-      } = json_response(conn, 403)
+               "ok" => false,
+               "code" => 403,
+               "detail" => "Forbidden",
+               "message" => _
+             } = json_response(conn, 403)
     end
 
     test "Requires being an admin", %{conn: conn} do
@@ -115,12 +120,13 @@ defmodule MalanWeb.SessionControllerTest do
 
       conn = Helpers.Accounts.put_token(conn, rs1.api_token)
       conn = get(conn, Routes.session_path(conn, :admin_index))
+
       assert %{
-        "ok" => false,
-        "code" => 401,
-        "detail" => "Unauthorized",
-        "message" => _
-      } = json_response(conn, 401)
+               "ok" => false,
+               "code" => 401,
+               "detail" => "Unauthorized",
+               "message" => _
+             } = json_response(conn, 401)
     end
 
     # test "Requires accepting ToS and PP", %{conn: conn} do
@@ -131,23 +137,23 @@ defmodule MalanWeb.SessionControllerTest do
     #   # When ToS and Privay Policy are required, uncomment the below
     #   conn = Helpers.Accounts.put_token(conn, as.api_token)
     #   conn = get(conn, Routes.session_path(conn, :admin_index))
-      # assert %{
-      #   "ok" => false,
-      #   "code" => 461,
-      #   "detail" => "Terms of Service Required",
-      #   "message" => _
-      # } = json_response(conn, 461)
+    # assert %{
+    #   "ok" => false,
+    #   "code" => 461,
+    #   "detail" => "Terms of Service Required",
+    #   "message" => _
+    # } = json_response(conn, 461)
 
     #   # Accept ToS
     #   {:ok, au} = Helpers.Accounts.accept_user_tos(au, true)
     #   conn = get(conn, Routes.session_path(conn, :admin_index))
     #   assert conn.status == 462
-      # assert %{
-      #   "ok" => false,
-      #   "code" => 462,
-      #   "detail" => "Terms of Service Required",
-      #   "message" => _
-      # } = json_response(conn, 462)
+    # assert %{
+    #   "ok" => false,
+    #   "code" => 462,
+    #   "detail" => "Terms of Service Required",
+    #   "message" => _
+    # } = json_response(conn, 462)
 
     #   # Accept Privacy Policy
     #   {:ok, _au} = Helpers.Accounts.accept_user_pp(au, true)
@@ -190,13 +196,15 @@ defmodule MalanWeb.SessionControllerTest do
       {:ok, conn, _au, _as} = Helpers.Accounts.admin_user_session_conn(conn)
 
       conn = delete(conn, Routes.session_path(conn, :admin_delete, rs.id))
+
       assert %{
-        "ok" => true,
-        "code" => 200,
-        "data" => %{
-          "revoked_at" => revoked_at
-        }
-      } = json_response(conn, 200)
+               "ok" => true,
+               "code" => 200,
+               "data" => %{
+                 "revoked_at" => revoked_at
+               }
+             } = json_response(conn, 200)
+
       {:ok, revoked_at, 0} = revoked_at |> DateTime.from_iso8601()
       assert TestUtils.DateTime.within_last?(revoked_at, 2, :seconds) == true
     end
@@ -205,12 +213,13 @@ defmodule MalanWeb.SessionControllerTest do
       {:ok, conn, _ru, rs} = Helpers.Accounts.regular_user_session_conn(conn)
 
       conn = delete(conn, Routes.session_path(conn, :admin_delete, rs.id))
+
       assert %{
-        "ok" => false,
-        "code" => 401,
-        "detail" => "Unauthorized",
-        "message" => _
-      } = json_response(conn, 401)
+               "ok" => false,
+               "code" => 401,
+               "detail" => "Unauthorized",
+               "message" => _
+             } = json_response(conn, 401)
     end
 
     test "Creates a corresponding Transaction", %{conn: conn} do
@@ -220,13 +229,15 @@ defmodule MalanWeb.SessionControllerTest do
         Helpers.Accounts.admin_user_session_conn(conn)
 
       conn = delete(conn, Routes.session_path(conn, :admin_delete, rs.id))
+
       assert %{
-        "ok" => true,
-        "code" => 200,
-        "data" => %{
-          "revoked_at" => revoked_at
-        }
-      } = json_response(conn, 200)
+               "ok" => true,
+               "code" => 200,
+               "data" => %{
+                 "revoked_at" => revoked_at
+               }
+             } = json_response(conn, 200)
+
       {:ok, revoked_at, 0} = revoked_at |> DateTime.from_iso8601()
       assert TestUtils.DateTime.within_last?(revoked_at, 2, :seconds) == true
 
@@ -255,22 +266,25 @@ defmodule MalanWeb.SessionControllerTest do
     test "lists all sessions for user", %{conn: conn} do
       # Require authentication
       conn = get(conn, Routes.user_session_path(conn, :index, "some id"))
+
       assert %{
-        "ok" => false,
-        "code" => 403,
-        "detail" => "Forbidden",
-        "message" => _
-      } = json_response(conn, 403)
+               "ok" => false,
+               "code" => 403,
+               "detail" => "Forbidden",
+               "message" => _
+             } = json_response(conn, 403)
 
       users = Helpers.Accounts.regular_users_session_conn(build_conn(), 3)
       {:ok, conn, ru1, rs1} = List.first(users)
 
       conn = get(conn, Routes.user_session_path(conn, :index, ru1.id))
+
       assert %{
-        "ok" => true,
-        "code" => 200,
-        "data" => data
-      } = json_response(conn, 200)
+               "ok" => true,
+               "code" => 200,
+               "data" => data
+             } = json_response(conn, 200)
+
       assert length(data) == 1
       assert data == [session_to_retval_map(rs1)]
     end
@@ -281,11 +295,13 @@ defmodule MalanWeb.SessionControllerTest do
       {:ok, ca, _au1, _as1} = Helpers.Accounts.admin_user_session_conn(build_conn())
 
       ca = get(ca, Routes.user_session_path(ca, :index, ru1.id))
+
       assert %{
-        "ok" => true,
-        "code" => 200,
-        "data" => data
-      } = json_response(ca, 200)
+               "ok" => true,
+               "code" => 200,
+               "data" => data
+             } = json_response(ca, 200)
+
       assert length(data) == 1
       assert data == [session_to_retval_map(rs1)]
     end
@@ -296,12 +312,13 @@ defmodule MalanWeb.SessionControllerTest do
       {:ok, c2, _ru2, _rs2} = Enum.at(users, 1)
 
       c2 = get(c2, Routes.user_session_path(c2, :index, ru1.id))
+
       assert %{
-        "ok" => false,
-        "code" => 401,
-        "detail" => "Unauthorized",
-        "message" => _
-      } = json_response(c2, 401)
+               "ok" => false,
+               "code" => 401,
+               "detail" => "Unauthorized",
+               "message" => _
+             } = json_response(c2, 401)
     end
 
     test "works with pagination", %{conn: conn} do
@@ -419,20 +436,23 @@ defmodule MalanWeb.SessionControllerTest do
 
     test "Must be authenticated", %{conn: conn} do
       conn = get(conn, Routes.session_path(conn, :index_active))
+
       assert %{
-        "ok" => false,
-        "code" => 403,
-        "detail" => "Forbidden",
-        "message" => _
-      } = json_response(conn, 403)
+               "ok" => false,
+               "code" => 403,
+               "detail" => "Forbidden",
+               "message" => _
+             } = json_response(conn, 403)
+
       conn = get(conn, Routes.user_session_path(conn, :user_index_active, "current"))
       assert conn.status == 403
+
       assert %{
-        "ok" => false,
-        "code" => 403,
-        "detail" => "Forbidden",
-        "message" => _
-      } = json_response(conn, 403)
+               "ok" => false,
+               "code" => 403,
+               "detail" => "Forbidden",
+               "message" => _
+             } = json_response(conn, 403)
     end
 
     test "can't be called by non-admin non-owner", %{conn: conn} do
@@ -449,11 +469,11 @@ defmodule MalanWeb.SessionControllerTest do
         )
 
       assert %{
-        "ok" => false,
-        "code" => 401,
-        "detail" => "Unauthorized",
-        "message" => _
-      } = json_response(c1, 401)
+               "ok" => false,
+               "code" => 401,
+               "detail" => "Unauthorized",
+               "message" => _
+             } = json_response(c1, 401)
     end
   end
 
@@ -463,12 +483,14 @@ defmodule MalanWeb.SessionControllerTest do
       user_id = user.id
       session_id = session.id
       conn = get(conn, Routes.session_path(conn, :show_current))
+
       assert %{
-        "ok" => false,
-        "code" => 403,
-        "detail" => "Forbidden",
-        "message" => _
-      } = json_response(conn, 403)
+               "ok" => false,
+               "code" => 403,
+               "detail" => "Forbidden",
+               "message" => _
+             } = json_response(conn, 403)
+
       conn = Helpers.Accounts.put_token(build_conn(), session.api_token)
       assert {:ok, _, _, _, _, _, _, _, _, _} = Accounts.validate_session(session.api_token, nil)
       conn = get(conn, Routes.session_path(conn, :show_current))
@@ -512,12 +534,13 @@ defmodule MalanWeb.SessionControllerTest do
       assert %{"id" => id, "api_token" => api_token} = json_response(conn, 201)["data"]
 
       conn = get(conn, Routes.user_session_path(conn, :show, user.id, id))
+
       assert %{
-        "ok" => false,
-        "code" => 403,
-        "detail" => "Forbidden",
-        "message" => _
-      } = json_response(conn, 403)
+               "ok" => false,
+               "code" => 403,
+               "detail" => "Forbidden",
+               "message" => _
+             } = json_response(conn, 403)
 
       conn = Helpers.Accounts.put_token(build_conn(), api_token)
       conn = get(conn, Routes.user_session_path(conn, :show, user.id, id))
@@ -555,11 +578,11 @@ defmodule MalanWeb.SessionControllerTest do
         )
 
       assert %{
-        "ok" => false,
-        "code" => 403,
-        "detail" => "Forbidden",
-        "message" => _
-      } = json_response(conn, 403)
+               "ok" => false,
+               "code" => 403,
+               "detail" => "Forbidden",
+               "message" => _
+             } = json_response(conn, 403)
     end
 
     test "invalid password", %{conn: conn} do
@@ -571,11 +594,11 @@ defmodule MalanWeb.SessionControllerTest do
         )
 
       assert %{
-        "ok" => false,
-        "code" => 403,
-        "detail" => "Forbidden",
-        "message" => _
-      } = json_response(conn, 403)
+               "ok" => false,
+               "code" => 403,
+               "detail" => "Forbidden",
+               "message" => _
+             } = json_response(conn, 403)
     end
 
     test "can be called by admin non-owner", %{conn: conn} do
@@ -631,12 +654,13 @@ defmodule MalanWeb.SessionControllerTest do
 
       {:ok, conn, _au, _as} = Helpers.Accounts.regular_user_session_conn(build_conn())
       conn = get(conn, Routes.user_session_path(conn, :show, user.id, id))
+
       assert %{
-        "ok" => false,
-        "code" => 401,
-        "detail" => "Unauthorized",
-        "message" => _
-      } = json_response(conn, 401)
+               "ok" => false,
+               "code" => 401,
+               "detail" => "Unauthorized",
+               "message" => _
+             } = json_response(conn, 401)
     end
 
     test "Allows creating tokens that never expire", %{conn: conn} do
@@ -830,11 +854,11 @@ defmodule MalanWeb.SessionControllerTest do
         )
 
       assert %{
-        "ok" => false,
-        "code" => 423,
-        "detail" => "Locked",
-        "message" => _
-      } = json_response(conn, 423)
+               "ok" => false,
+               "code" => 423,
+               "detail" => "Locked",
+               "message" => _
+             } = json_response(conn, 423)
 
       assert [
                ^tx_locked,
@@ -866,11 +890,11 @@ defmodule MalanWeb.SessionControllerTest do
         )
 
       assert %{
-        "ok" => false,
-        "code" => 403,
-        "detail" => "Forbidden",
-        "message" => _
-      } = json_response(conn, 403)
+               "ok" => false,
+               "code" => 403,
+               "detail" => "Forbidden",
+               "message" => _
+             } = json_response(conn, 403)
 
       assert [
                %Transaction{
@@ -904,11 +928,11 @@ defmodule MalanWeb.SessionControllerTest do
         )
 
       assert %{
-        "ok" => false,
-        "code" => 403,
-        "detail" => "Forbidden",
-        "message" => _
-      } = json_response(conn, 403)
+               "ok" => false,
+               "code" => 403,
+               "detail" => "Forbidden",
+               "message" => _
+             } = json_response(conn, 403)
 
       assert [
                %Transaction{
@@ -998,12 +1022,13 @@ defmodule MalanWeb.SessionControllerTest do
       # Make sure the token now doesn't work
       conn = Helpers.Accounts.put_token(build_conn(), api_token)
       conn = get(conn, Routes.user_session_path(conn, :show, user.id, id))
+
       assert %{
-        "ok" => false,
-        "code" => 403,
-        "detail" => "Forbidden",
-        "message" => _
-      } = json_response(conn, 403)
+               "ok" => false,
+               "code" => 403,
+               "detail" => "Forbidden",
+               "message" => _
+             } = json_response(conn, 403)
     end
 
     test "Create session fails if IP isn't approved for user", %{conn: conn} do
@@ -1019,11 +1044,11 @@ defmodule MalanWeb.SessionControllerTest do
         )
 
       assert %{
-        "ok" => false,
-        "code" => 403,
-        "detail" => "Forbidden",
-        "message" => _
-      } = json_response(conn, 403)
+               "ok" => false,
+               "code" => 403,
+               "detail" => "Forbidden",
+               "message" => _
+             } = json_response(conn, 403)
     end
   end
 
@@ -1031,12 +1056,14 @@ defmodule MalanWeb.SessionControllerTest do
     test "deletes chosen session", %{conn: conn} do
       {:ok, user, session} = Helpers.Accounts.regular_user_with_session()
       conn = delete(conn, Routes.user_session_path(conn, :delete, user.id, session))
+
       assert %{
-        "ok" => false,
-        "code" => 403,
-        "detail" => "Forbidden",
-        "message" => _
-      } = json_response(conn, 403)
+               "ok" => false,
+               "code" => 403,
+               "detail" => "Forbidden",
+               "message" => _
+             } = json_response(conn, 403)
+
       conn = Helpers.Accounts.put_token(build_conn(), session.api_token)
       conn = delete(conn, Routes.user_session_path(conn, :delete, user.id, session))
 
@@ -1062,12 +1089,13 @@ defmodule MalanWeb.SessionControllerTest do
       {:ok, user, session} = Helpers.Accounts.regular_user_with_session()
       {:ok, conn, _ru, _rs} = Helpers.Accounts.regular_user_session_conn(conn)
       conn = delete(conn, Routes.user_session_path(conn, :delete, user.id, session))
+
       assert %{
-        "ok" => false,
-        "code" => 401,
-        "detail" => "Unauthorized",
-        "message" => _
-      } = json_response(conn, 401)
+               "ok" => false,
+               "code" => 401,
+               "detail" => "Unauthorized",
+               "message" => _
+             } = json_response(conn, 401)
     end
 
     test "Creates a corresponding Transaction", %{conn: conn} do
@@ -1076,10 +1104,11 @@ defmodule MalanWeb.SessionControllerTest do
 
       conn = Helpers.Accounts.put_token(conn, session.api_token)
       conn = delete(conn, Routes.user_session_path(conn, :delete, user_id, session))
+
       assert %{
-        "ok" => true,
-        "code" => 200,
-      } = json_response(conn, 200)
+               "ok" => true,
+               "code" => 200
+             } = json_response(conn, 200)
 
       assert [
                %Transaction{
@@ -1158,12 +1187,14 @@ defmodule MalanWeb.SessionControllerTest do
       {:ok, s4} = Helpers.Accounts.create_session(user)
 
       conn = delete(conn, Routes.user_session_path(conn, :delete_all, user.id))
+
       assert %{
-        "ok" => false,
-        "code" => 403,
-        "detail" => "Forbidden",
-        "message" => _
-      } = json_response(conn, 403)
+               "ok" => false,
+               "code" => 403,
+               "detail" => "Forbidden",
+               "message" => _
+             } = json_response(conn, 403)
+
       conn = Helpers.Accounts.put_token(build_conn(), s1.api_token)
 
       for s <- [s1, s2, s3, s4] do
@@ -1192,12 +1223,14 @@ defmodule MalanWeb.SessionControllerTest do
       {:ok, s4} = Helpers.Accounts.create_session(ru)
 
       conn = delete(conn, Routes.user_session_path(conn, :delete_all, ru.id))
+
       assert %{
-        "ok" => false,
-        "code" => 403,
-        "detail" => "Forbidden",
-        "message" => _
-      } = json_response(conn, 403)
+               "ok" => false,
+               "code" => 403,
+               "detail" => "Forbidden",
+               "message" => _
+             } = json_response(conn, 403)
+
       conn = Helpers.Accounts.put_token(build_conn(), as.api_token)
 
       for s <- [s1, s2, s3, s4] do
@@ -1222,20 +1255,23 @@ defmodule MalanWeb.SessionControllerTest do
       {:ok, user} = Helpers.Accounts.regular_user()
 
       conn = delete(conn, Routes.user_session_path(conn, :delete_all, user.id))
+
       assert %{
-        "ok" => false,
-        "code" => 403,
-        "detail" => "Forbidden",
-        "message" => _
-      } = json_response(conn, 403)
+               "ok" => false,
+               "code" => 403,
+               "detail" => "Forbidden",
+               "message" => _
+             } = json_response(conn, 403)
+
       conn = Helpers.Accounts.put_token(build_conn(), rs.api_token)
       conn = delete(conn, Routes.user_session_path(conn, :delete_all, user.id))
+
       assert %{
-        "ok" => false,
-        "code" => 401,
-        "detail" => "Unauthorized",
-        "message" => _
-      } = json_response(conn, 401)
+               "ok" => false,
+               "code" => 401,
+               "detail" => "Unauthorized",
+               "message" => _
+             } = json_response(conn, 401)
     end
 
     test "Creates a corresponding Transaction", %{conn: conn} do

--- a/test/malan_web/controllers/user_controller_test.exs
+++ b/test/malan_web/controllers/user_controller_test.exs
@@ -162,7 +162,7 @@ defmodule MalanWeb.UserControllerTest do
                "code" => 200,
                "data" => users,
                "page_num" => @default_page_num,
-               "page_size" => @default_page_size,
+               "page_size" => @default_page_size
              } = json_response(conn, 200)
 
       assert Enum.any?(users, fn u ->
@@ -317,6 +317,7 @@ defmodule MalanWeb.UserControllerTest do
       conn = Helpers.Accounts.put_token(Phoenix.ConnTest.build_conn(), session.api_token)
 
       conn = get(conn, Routes.user_path(conn, :show, id), abbr: 1)
+
       assert %{
                "ok" => true,
                "code" => 200,
@@ -393,6 +394,7 @@ defmodule MalanWeb.UserControllerTest do
       preferences = Utils.map_atom_keys_to_strings(preferences)
 
       conn = get(conn, Routes.user_path(conn, :show, id), abbr: 1)
+
       assert %{
                "ok" => true,
                "code" => 200,
@@ -402,7 +404,6 @@ defmodule MalanWeb.UserControllerTest do
                  "preferences" => ^preferences
                }
              } = json_response(conn, 200)
-
     end
 
     test "renders errors when data is invalid", %{conn: conn} do


### PR DESCRIPTION
- Add `ok: true` to success responses for users and sessions.  
- Also add the `code: 200` to success responses.
- Also improve the tests a bit to check for more things
- Refactor template code to be more thorough and cleaner

Fixes #110 