### PR TITLE
When deleting a user, revoke all active sessions

### DIFF
--- a/lib/malan/accounts.ex
+++ b/lib/malan/accounts.ex
@@ -433,11 +433,12 @@ defmodule Malan.Accounts do
       {:error, %Ecto.Changeset{}}
 
   """
-  def delete_user(%User{} = user) do
-    # Repo.delete(user)
-    user
-    |> User.delete_changeset()
-    |> Repo.update()
+  def delete_user(%User{} = user, remote_ip \\ dummy_ip()) do
+    with {:ok, _num_revoked} <- revoke_active_sessions(user, remote_ip) do
+      user
+      |> User.delete_changeset()
+      |> Repo.update()
+    end
   end
 
   def lock_user(%User{} = user, locked_by_id, remote_ip \\ dummy_ip()) do

--- a/test/malan_web/controllers/user_controller_test.exs
+++ b/test/malan_web/controllers/user_controller_test.exs
@@ -1644,6 +1644,28 @@ defmodule MalanWeb.UserControllerTest do
                "token_expired" => true
              } = json_response(conn, 403)
     end
+
+    test "Rejects with 403 when user is deleted and had active sessions", %{
+      conn: conn,
+      user: %User{} = user,
+      session: %Session{} = session
+    } do
+      assert is_nil(session.revoked_at)
+      #session = Helpers.Accounts.set_revoked(session)
+      #assert not is_nil(session.revoked_at)
+      assert {:ok, %User{}} = Accounts.delete_user(user)
+
+      conn = Helpers.Accounts.put_token(conn, session.api_token)
+      conn = get(conn, Routes.user_path(conn, :whoami))
+
+      assert %{
+               "ok" => false,
+               "code" => 403,
+               "detail" => "Forbidden",
+               "message" => "API token is expired or revoked",
+               "token_expired" => true
+             } = json_response(conn, 403)
+    end
   end
 
   describe "reset_password" do


### PR DESCRIPTION
    When deleting a user, revoke all active sessions
    
    When a user is deleted, all of their active sessions should be
    automatically revoked.  The session isn't usable for anything, but
    should be revoked nonetheless for completeness.
    
    Adds a handful of tests around this functionality.  Updates some tests
    that were impacted.  Adds a test for access control around user deletion
    to ensure that only admins or the user themselves can delete the user.
    
    Fixes #112

    Add test for whoami endpoint /api/users/whoami on user deletion
    
    Add test to make sure that after a user is deleted, the whoami call does
    not succeed.  It should 403 with token expired or revoked.
