### PR TITLE
Use the exception-free version of user get functions

### DIFF
--- a/lib/malan_web/controllers/user_controller.ex
+++ b/lib/malan_web/controllers/user_controller.ex
@@ -159,7 +159,7 @@ defmodule MalanWeb.UserController do
   end
 
   def lock(conn, %{"id" => id}) do
-    user = Accounts.get_user_by_id_or_username!(id)
+    user = Accounts.get_user_by_id_or_username(id)
 
     if is_nil(user) do
       render_user(conn, user)
@@ -211,7 +211,7 @@ defmodule MalanWeb.UserController do
   end
 
   def unlock(conn, %{"id" => id}) do
-    user = Accounts.get_user_by_id_or_username!(id)
+    user = Accounts.get_user_by_id_or_username(id)
 
     if is_nil(user) do
       render_user(conn, user)
@@ -250,7 +250,7 @@ defmodule MalanWeb.UserController do
   end
 
   def delete(conn, %{"id" => id}) do
-    user = Accounts.get_user_by_id_or_username!(id)
+    user = Accounts.get_user_by_id_or_username(id)
 
     if is_nil(user) do
       render_user(conn, user)


### PR DESCRIPTION
In the User Controller we don't want to use the exception throwing
version of these methods.

Fixes #118