### PR TITLE
Refactor uuidgen to remove dependency on Ecto

### DIFF
--- a/lib/malan/utils.ex
+++ b/lib/malan/utils.ex
@@ -230,7 +230,7 @@ defmodule Malan.Utils do
   end
 
   @doc ~S"""
-  Generate a new UUIDv4
+  Generate a new random UUIDv4
 
   ## Examples
 
@@ -239,7 +239,7 @@ defmodule Malan.Utils do
 
   """
   def uuidgen(),
-    do: Ecto.UUID.generate()
+    do: bingenerate() |> encode()
 
   @doc ~S"""
   Quick regex check to see if the supplied `string` is a valid UUID
@@ -548,6 +548,62 @@ defmodule Malan.Utils do
   def true_or_explicitly_false?(val) when is_binary(val), do: not explicitly_false?(val)
   def true_or_explicitly_false?(nil), do: true
   def true_or_explicitly_false?(val) when is_atom(val), do: !!val
+
+  # Derived from `Ecto` library.  Apache 2.0 licensed.
+  @typedoc """
+  A raw binary representation of a UUID.
+  """
+  @type uuid_raw :: <<_::128>>
+
+  # Derived from `Ecto` library.  Apache 2.0 licensed.
+  @typedoc """
+  A hex-encoded UUID string.
+  """
+  @type uuid :: <<_::288>>
+
+  # Derived from `Ecto` library.  Apache 2.0 licensed.
+  @spec bingenerate() :: uuid_raw
+  defp bingenerate() do
+    <<u0::48, _::4, u1::12, _::2, u2::62>> = :crypto.strong_rand_bytes(16)
+    <<u0::48, 4::4, u1::12, 2::2, u2::62>>
+  end
+
+  # Derived from `Ecto` library.  Apache 2.0 licensed.
+  @spec encode(uuid_raw) :: uuid
+  defp encode(<< a1::4, a2::4, a3::4, a4::4,
+                 a5::4, a6::4, a7::4, a8::4,
+                 b1::4, b2::4, b3::4, b4::4,
+                 c1::4, c2::4, c3::4, c4::4,
+                 d1::4, d2::4, d3::4, d4::4,
+                 e1::4, e2::4, e3::4, e4::4,
+                 e5::4, e6::4, e7::4, e8::4,
+                 e9::4, e10::4, e11::4, e12::4 >>) do
+    << e(a1), e(a2), e(a3), e(a4), e(a5), e(a6), e(a7), e(a8), ?-,
+       e(b1), e(b2), e(b3), e(b4), ?-,
+       e(c1), e(c2), e(c3), e(c4), ?-,
+       e(d1), e(d2), e(d3), e(d4), ?-,
+       e(e1), e(e2), e(e3), e(e4), e(e5), e(e6), e(e7), e(e8), e(e9), e(e10), e(e11), e(e12) >>
+  end
+
+  @compile {:inline, e: 1}
+
+  # Derived from `Ecto` library.  Apache 2.0 licensed.
+  defp e(0),  do: ?0
+  defp e(1),  do: ?1
+  defp e(2),  do: ?2
+  defp e(3),  do: ?3
+  defp e(4),  do: ?4
+  defp e(5),  do: ?5
+  defp e(6),  do: ?6
+  defp e(7),  do: ?7
+  defp e(8),  do: ?8
+  defp e(9),  do: ?9
+  defp e(10), do: ?a
+  defp e(11), do: ?b
+  defp e(12), do: ?c
+  defp e(13), do: ?d
+  defp e(14), do: ?e
+  defp e(15), do: ?f
 end
 
 defmodule Malan.Utils.Enum do

--- a/test/malan/utils_test.exs
+++ b/test/malan/utils_test.exs
@@ -58,8 +58,23 @@ defmodule Malan.UtilsTest do
     end
 
     test "#uuidgen/0" do
-      assert Utils.uuidgen() =~
-               ~r/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/
+      uuid_regex = ~r/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/
+
+      # Quick sanity test to fail fast
+      assert Utils.uuidgen() =~ uuid_regex
+
+      # Run through a number of invocations and ensure no collisions
+      num_vals = 1_000_000
+
+      set =
+        Enum.reduce(1..num_vals, MapSet.new(), fn _, acc ->
+          next_uuid = Utils.uuidgen()
+          assert next_uuid =~ uuid_regex
+          assert !MapSet.member?(acc, next_uuid)
+          MapSet.put(acc, Utils.uuidgen())
+        end)
+
+      assert MapSet.size(set) == num_vals
     end
 
     test "#is_uuid?/1" do


### PR DESCRIPTION
This is a useful utility function, but as written requires ecto as
a dependency.  This is fine for phoenix apps, but horrible for
non-phoenix apps.

Refactor the function to work the same but without the dependency on
Ecto

Also adds some uniqueness tests to supplement the existing format tests