### PR TITLE
Fix flaky pagination tests

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -80,7 +80,7 @@ defmodule Malan.MixProject do
       "ecto.setup": ["ecto.create", "ecto.migrate", "run priv/repo/seeds.exs"],
       "ecto.reset": ["ecto.drop", "ecto.setup"],
       "ecto.create.migrate": ["ecto.create", "ecto.migrate"],
-      test: ["ecto.create --quiet", "ecto.migrate --quiet", "test"],
+      test: ["ecto.create --quiet", "ecto.migrate --quiet", "run priv/repo/seeds.exs", "test"],
       "assets.deploy": [
         "cmd --cd assets npm run deploy",
         "esbuild default --minify",

--- a/test/malan/accounts_test.exs
+++ b/test/malan/accounts_test.exs
@@ -67,9 +67,13 @@ defmodule Malan.AccountsTest do
     def assert_list_users_eq(l1, l2) do
       assert Enum.count(l1) == Enum.count(l2)
 
-      l1
-      |> Enum.with_index()
-      |> Enum.each(fn {u, i} -> assert users_eq(u, Enum.at(l2, i)) end)
+      # Check for equality ignoring order
+      TestUtils.lists_equal_ignore_order(l1, l2)
+
+      # Check for exact equality (including order)
+      # l1
+      # |> Enum.with_index()
+      # |> Enum.each(fn {u, i} -> assert users_eq(u, Enum.at(l2, i)) end)
     end
 
     test "list_users/2 returns all users" do
@@ -91,9 +95,21 @@ defmodule Malan.AccountsTest do
       assert lu |> Enum.count() == 3
       assert_list_users_eq(lu, [u1, u2, u3])
 
-      assert users_eq(u1, Accounts.list_users(1, 1) |> Enum.at(0))
-      assert users_eq(u2, Accounts.list_users(2, 1) |> Enum.at(0))
-      assert users_eq(u3, Accounts.list_users(3, 1) |> Enum.at(0))
+      assert Accounts.list_users(1, 1) |> Enum.count() == 1
+      assert Accounts.list_users(2, 1) |> Enum.count() == 1
+      assert Accounts.list_users(3, 1) |> Enum.count() == 1
+
+      [
+        Accounts.list_users(1, 1) |> Enum.at(0),
+        Accounts.list_users(2, 1) |> Enum.at(0),
+        Accounts.list_users(3, 1) |> Enum.at(0)
+      ]
+      |> TestUtils.lists_equal_ignore_order([u1, u2, u3])
+
+      # Flaky code
+      # assert users_eq(u1, Accounts.list_users(1, 1) |> Enum.at(0))
+      # assert users_eq(u2, Accounts.list_users(2, 1) |> Enum.at(0))
+      # assert users_eq(u3, Accounts.list_users(3, 1) |> Enum.at(0))
     end
 
     test "get_user!/1 returns the user with given id" do
@@ -938,17 +954,47 @@ defmodule Malan.AccountsTest do
       {:ok, s5} = Helpers.Accounts.create_session(u1)
       {:ok, s6} = Helpers.Accounts.create_session(u1)
 
-      assert Accounts.list_sessions(0, 10) == nillify_api_token([s1, s2, s3, s4, s5, s6])
-      assert Accounts.list_sessions(1, 10) == []
+      assert TestUtils.lists_equal_ignore_order(
+               Accounts.list_sessions(0, 10),
+               nillify_api_token([s1, s2, s3, s4, s5, s6])
+             )
 
-      assert Accounts.list_sessions(0, 2) == nillify_api_token([s1, s2])
-      assert Accounts.list_sessions(1, 2) == nillify_api_token([s3, s4])
-      assert Accounts.list_sessions(2, 2) == nillify_api_token([s5, s6])
-      assert Accounts.list_sessions(3, 2) == nillify_api_token([])
+      assert TestUtils.lists_equal_ignore_order(Accounts.list_sessions(1, 10), [])
 
-      assert Accounts.list_sessions(0, 4) == nillify_api_token([s1, s2, s3, s4])
-      assert Accounts.list_sessions(1, 4) == nillify_api_token([s5, s6])
-      assert Accounts.list_sessions(2, 4) == nillify_api_token([])
+      assert TestUtils.lists_equal_ignore_order(
+               Accounts.list_sessions(0, 2),
+               nillify_api_token([s1, s2])
+             )
+
+      assert TestUtils.lists_equal_ignore_order(
+               Accounts.list_sessions(1, 2),
+               nillify_api_token([s3, s4])
+             )
+
+      assert TestUtils.lists_equal_ignore_order(
+               Accounts.list_sessions(2, 2),
+               nillify_api_token([s5, s6])
+             )
+
+      assert TestUtils.lists_equal_ignore_order(
+               Accounts.list_sessions(3, 2),
+               nillify_api_token([])
+             )
+
+      assert TestUtils.lists_equal_ignore_order(
+               Accounts.list_sessions(0, 4),
+               nillify_api_token([s1, s2, s3, s4])
+             )
+
+      assert TestUtils.lists_equal_ignore_order(
+               Accounts.list_sessions(1, 4),
+               nillify_api_token([s5, s6])
+             )
+
+      assert TestUtils.lists_equal_ignore_order(
+               Accounts.list_sessions(2, 4),
+               nillify_api_token([])
+             )
     end
 
     test "get_session!/1 returns the session with given id" do

--- a/test/malan_web/controllers/user_controller_test.exs
+++ b/test/malan_web/controllers/user_controller_test.exs
@@ -193,11 +193,12 @@ defmodule MalanWeb.UserControllerTest do
       conn = get(conn, Routes.user_path(conn, :index))
 
       assert %{
-        "ok" => false,
-        "code" => 403,
-        "detail" => "Forbidden",
-        "message" => "Anonymous access to this method on this object is not allowed.  You must authenticate and pass a valid token."
-      } == json_response(conn, 403)
+               "ok" => false,
+               "code" => 403,
+               "detail" => "Forbidden",
+               "message" =>
+                 "Anonymous access to this method on this object is not allowed.  You must authenticate and pass a valid token."
+             } == json_response(conn, 403)
     end
 
     test "requires being an admin to access (as regular user)", %{conn: conn} do
@@ -206,11 +207,12 @@ defmodule MalanWeb.UserControllerTest do
       conn = get(conn, Routes.user_path(conn, :index))
 
       assert %{
-        "ok" => false,
-        "code" => 401,
-        "detail" => "Unauthorized",
-        "message" => "You are authenticated but do not have access to this method on this object."
-      } == json_response(conn, 401)
+               "ok" => false,
+               "code" => 401,
+               "detail" => "Unauthorized",
+               "message" =>
+                 "You are authenticated but do not have access to this method on this object."
+             } == json_response(conn, 401)
     end
 
     test "requires being an admin to access (as moderator)", %{conn: conn} do
@@ -219,11 +221,12 @@ defmodule MalanWeb.UserControllerTest do
       conn = get(conn, Routes.user_path(conn, :index))
 
       assert %{
-        "ok" => false,
-        "code" => 401,
-        "detail" => "Unauthorized",
-        "message" => "You are authenticated but do not have access to this method on this object."
-      } == json_response(conn, 401)
+               "ok" => false,
+               "code" => 401,
+               "detail" => "Unauthorized",
+               "message" =>
+                 "You are authenticated but do not have access to this method on this object."
+             } == json_response(conn, 401)
     end
 
     test "Works with pagination (as admin)", %{conn: conn} do
@@ -1006,11 +1009,12 @@ defmodule MalanWeb.UserControllerTest do
       conn = get(conn, Routes.user_path(conn, :index))
 
       assert %{
-        "ok" => false,
-        "code" => 401,
-        "detail" => "Unauthorized",
-        "message" => "You are authenticated but do not have access to this method on this object."
-      } == json_response(conn, 401)
+               "ok" => false,
+               "code" => 401,
+               "detail" => "Unauthorized",
+               "message" =>
+                 "You are authenticated but do not have access to this method on this object."
+             } == json_response(conn, 401)
     end
 
     test "Allows updating phone numbers", %{conn: conn, user: %User{} = user} do
@@ -1474,7 +1478,7 @@ defmodule MalanWeb.UserControllerTest do
       assert [
                %Transaction{
                  success: true,
-                 #user_id: ^id,
+                 # user_id: ^id,
                  user_id: nil,
                  session_id: nil,
                  type_enum: 1,
@@ -1655,8 +1659,8 @@ defmodule MalanWeb.UserControllerTest do
       session: %Session{} = session
     } do
       assert is_nil(session.revoked_at)
-      #session = Helpers.Accounts.set_revoked(session)
-      #assert not is_nil(session.revoked_at)
+      # session = Helpers.Accounts.set_revoked(session)
+      # assert not is_nil(session.revoked_at)
       assert {:ok, %User{}} = Accounts.delete_user(user)
 
       conn = Helpers.Accounts.put_token(conn, session.api_token)

--- a/test/malan_web/controllers/user_controller_test.exs
+++ b/test/malan_web/controllers/user_controller_test.exs
@@ -97,9 +97,13 @@ defmodule MalanWeb.UserControllerTest do
     l1 = Enum.map(l1, fn u -> strip_user(u) end)
     l2 = Enum.map(l2, fn u -> strip_user(u) end)
 
-    l1
-    |> Enum.with_index()
-    |> Enum.each(fn {u, i} -> assert u == Enum.at(l2, i) end)
+    # Check for equality ignoring order
+    TestUtils.lists_equal_ignore_order(l1, l2, &(&1["id"]))
+
+    # Check for exact equality (including order)
+    # l1
+    # |> Enum.with_index()
+    # |> Enum.each(fn {u, i} -> assert u == Enum.at(l2, i) end)
   end
 
   setup %{conn: conn} do

--- a/test/support/test_utils.ex
+++ b/test/support/test_utils.ex
@@ -13,12 +13,20 @@ defmodule Malan.Test.Utils do
     lists_equal_ignore_order(list1, list2, &(&1.id))
   end
 
+  def lists_equal_ignore_order_sort_by_id_str(list1, list2) do
+    lists_equal_ignore_order(list1, list2, &(&1["id"]))
+  end
+
   def sort_by(list, mapper, type \\ :asc) do
     Enum.sort_by(list, mapper, type)
   end
 
   def sort_by_id(list, type \\ :asc) do
     Enum.sort_by(list, &(&1.id), type)
+  end
+
+  def sort_by_id_str(list, type \\ :asc) do
+    Enum.sort_by(list, &(&1["id"]), type)
   end
 end
 

--- a/test/support/test_utils.ex
+++ b/test/support/test_utils.ex
@@ -1,4 +1,25 @@
 defmodule Malan.Test.Utils do
+  def lists_equal_ignore_order(list1, list2) do
+    lists_equal_ignore_order(list1, list2, &(&1))
+  end
+
+  def lists_equal_ignore_order(list1, list2, mapper, type \\ :asc) do
+    l1 = Enum.sort_by(list1, mapper, type)
+    l2 = Enum.sort_by(list2, mapper, type)
+    l1 == l2
+  end
+
+  def lists_equal_ignore_order_sort_by_id(list1, list2) do
+    lists_equal_ignore_order(list1, list2, &(&1.id))
+  end
+
+  def sort_by(list, mapper, type \\ :asc) do
+    Enum.sort_by(list, mapper, type)
+  end
+
+  def sort_by_id(list, type \\ :asc) do
+    Enum.sort_by(list, &(&1.id), type)
+  end
 end
 
 defmodule Malan.Test.Utils.Controller do

--- a/test/tests/test_utils_test.exs
+++ b/test/tests/test_utils_test.exs
@@ -3,6 +3,92 @@ defmodule Malan.TestUtilsTest do
 
   use ExUnit.Case, async: true
 
+  describe "TestUtils" do
+    defp fy, do: "Fort Yuma"
+    defp fa, do: "Fort Apache"
+    defp gc, do: "General Crook"
+
+    # l1 and l2 are equal (though out of order)
+    defp l1, do: [%{id: 1, name: fa()}, %{id: 3, name: fy()}, %{id: 2, name: gc()}]
+    defp l2, do: [%{id: 2, name: gc()}, %{id: 1, name: fa()}, %{id: 3, name: fy()}]
+
+    # l3 and l4 are unique (different than l1 and l2 and each other)
+    defp l3, do: [%{id: 2, name: fa()}, %{id: 1, name: fy()}, %{id: 3, name: gc()}]
+    defp l4, do: [%{id: 2, name: fy()}, %{id: 1, name: gc()}, %{id: 3, name: fa()}]
+
+    defp l5, do: [3, 1, 2]
+    defp l6, do: [1, 3, 2]
+
+    defp l1_id_asc, do: [%{id: 1, name: fa()}, %{id: 2, name: gc()}, %{id: 3, name: fy()}]
+    defp l1_id_desc, do: [%{id: 3, name: fy()}, %{id: 2, name: gc()}, %{id: 1, name: fa()}]
+
+    defp l1_name_asc, do: [%{id: 1, name: fa()}, %{id: 3, name: fy()}, %{id: 2, name: gc()}]
+    defp l1_name_desc, do: [%{id: 2, name: gc()}, %{id: 3, name: fy()}, %{id: 1, name: fa()}]
+
+    test "#lists_equal_ignore_order/2 works" do
+      assert TestUtils.lists_equal_ignore_order(l1(), l2())
+      assert TestUtils.lists_equal_ignore_order(l2(), l1())
+
+      assert TestUtils.lists_equal_ignore_order(l5(), l5())
+      assert TestUtils.lists_equal_ignore_order(l5(), l6())
+      assert TestUtils.lists_equal_ignore_order(l6(), l6())
+
+      assert not TestUtils.lists_equal_ignore_order(l1(), l3())
+      assert not TestUtils.lists_equal_ignore_order(l1(), l4())
+      assert not TestUtils.lists_equal_ignore_order(l2(), l3())
+      assert not TestUtils.lists_equal_ignore_order(l2(), l4())
+
+      assert not TestUtils.lists_equal_ignore_order(l2(), l5())
+    end
+
+    test "#lists_equal_ignore_order/3 properly shows equal" do
+      assert TestUtils.lists_equal_ignore_order(l1(), l2(), &(&1))
+      assert TestUtils.lists_equal_ignore_order(l5(), l6(), &(&1))
+      assert TestUtils.lists_equal_ignore_order(l1(), l2(), &(&1.id))
+      assert TestUtils.lists_equal_ignore_order(l1(), l2(), &(&1.name))
+      assert TestUtils.lists_equal_ignore_order(l1(), l2(), &("Henry Fonda" <> &1.name))
+
+      assert not TestUtils.lists_equal_ignore_order(l1(), l3(), &(&1))
+      assert not TestUtils.lists_equal_ignore_order(l1(), l4(), &(&1))
+      assert not TestUtils.lists_equal_ignore_order(l2(), l3(), &(&1))
+      assert not TestUtils.lists_equal_ignore_order(l2(), l4(), &(&1))
+
+      assert not TestUtils.lists_equal_ignore_order(l1(), l3(), &(&1.id))
+      assert not TestUtils.lists_equal_ignore_order(l1(), l4(), &(&1.id))
+      assert not TestUtils.lists_equal_ignore_order(l2(), l3(), &(&1.id))
+      assert not TestUtils.lists_equal_ignore_order(l2(), l4(), &(&1.id))
+
+      assert not TestUtils.lists_equal_ignore_order(l1(), l3(), &(&1.name))
+      assert not TestUtils.lists_equal_ignore_order(l1(), l4(), &(&1.name))
+      assert not TestUtils.lists_equal_ignore_order(l2(), l3(), &(&1.name))
+      assert not TestUtils.lists_equal_ignore_order(l2(), l4(), &(&1.name))
+
+      assert not TestUtils.lists_equal_ignore_order(l1(), l3(), &("Henry Fonda" <> &1.name))
+      assert not TestUtils.lists_equal_ignore_order(l1(), l4(), &("Henry Fonda" <> &1.name))
+      assert not TestUtils.lists_equal_ignore_order(l2(), l3(), &("Henry Fonda" <> &1.name))
+      assert not TestUtils.lists_equal_ignore_order(l2(), l4(), &("Henry Fonda" <> &1.name))
+    end
+
+    test "#sort_by/3 sorts in proper order" do
+      assert l1_id_asc() == TestUtils.sort_by(l1(), &(&1.id))
+      assert l1_id_asc() == TestUtils.sort_by(l1(), &(&1.id), :asc)
+
+      assert l1_id_desc() == TestUtils.sort_by(l1(), &(&1.id), :desc)
+
+      assert l1_name_asc() == TestUtils.sort_by(l1(), &(&1.name))
+      assert l1_name_asc() == TestUtils.sort_by(l1(), &(&1.name), :asc)
+
+      assert l1_name_desc() == TestUtils.sort_by(l1(), &(&1.name), :desc)
+    end
+
+    test "#sort_by_id/3 sorts in proper order by id" do
+      assert l1_id_asc() == TestUtils.sort_by_id(l1())
+      assert l1_id_asc() == TestUtils.sort_by_id(l1(), :asc)
+
+      assert l1_id_desc() == TestUtils.sort_by_id(l1(), :desc)
+    end
+  end
+
   describe "DateTime" do
     test "#plus_or_minus?/4" do
       {:ok, d1, 0} = DateTime.from_iso8601("2020-01-01T00:00:00Z")


### PR DESCRIPTION
commit 8af05858a5bae8b5b7b6bc38c7b6a93975881b68
Author: Benjamin Porter <FreedomBen@users.noreply.github.com>
Date:   Thu Aug 11 19:51:29 2022 -0600

    Automatically seed test database
    
    The tests expect the seeds to be in place, so we should automatically
    run them to ensure database consistency for the test environment
    
    Fixes #122

commit 02d02ba12eecda7eb8aaf268d786a76e572e4c6b
Author: Benjamin Porter <FreedomBen@users.noreply.github.com>
Date:   Thu Aug 11 18:47:23 2022 -0600

    Fix up flaky tests
    
    Rewrite the pagination tests to be permissive on the order in which they
    are returned.  This fixes a fragility in pagination tests.
    
    - The flakiness is a result of the tests expecting a deterministic order for objects created
    - Running tests serially (synchronously) makes no difference
    - Running tests against a completely fresh DB instance makes no difference
    - Postgres is not deterministic in this. That's not a problem, just an implementation reality
    
    The fix is to rewrite the tests in a way that the lists are sorted
    before comparison.  The net result is that order doesn't matter but
    membership (and length) does:
    
    Fixes #117

commit afc9bf5225157f7f968f6e8b4b78c7deb67c32ae
Author: Benjamin Porter <FreedomBen@users.noreply.github.com>
Date:   Thu Aug 11 16:44:09 2022 -0600

    Add test utilities for comparing lists that are unordered
    
    This will be needed to fix the flaky pagination tests
