### PR TITLE
Fix `#Accounts.get_user_by/1` for deleted users

### DIFF
--- a/lib/malan/accounts.ex
+++ b/lib/malan/accounts.ex
@@ -210,40 +210,42 @@ defmodule Malan.Accounts do
   end
 
   @doc ~S"""
-  Returns nil if no matching user is found.
+  Retrieve the user matching the specified param(s) or `nil`.
+
+  Returns `%User{}` if found, raises Ecto.NoResultsError if not found
+
+  Returns `nil` if no matching user is found.
   Raises Ecto.MultipleResultsError if more than one is found:  https://hexdocs.pm/ecto/Ecto.MultipleResultsError.html
 
-      iex> Accounts.get_user_by(title: "My post")
+      iex> Accounts.get_user_by(email: "brad@example.com")
 
   """
   def get_user_by(params) do
-    # TODO: Don't return users where deleted_at is not nil
-    Repo.get_by(User, params)
+    User
+    |> where([u], is_nil(u.deleted_at))
+    |> Repo.get_by(params)
   end
 
   @doc ~S"""
-  Raises Ecto.NoResultsError if no matching user is found.  https://hexdocs.pm/ecto/Ecto.NoResultsError.html
-  Raises Ecto.MultipleResultsError if more than one is found:  https://hexdocs.pm/ecto/Ecto.MultipleResultsError.html
+  Retrieve the user matching the specified param(s).
 
-      iex> Accounts.get_user_by!(title: "My post")
+  Returns `%User{}` if found, raises Ecto.NoResultsError if not found
+
+  Raises `Ecto.NoResultsError` if no matching user is found.  https://hexdocs.pm/ecto/Ecto.NoResultsError.html
+  Raises `Ecto.MultipleResultsError` if more than one is found:  https://hexdocs.pm/ecto/Ecto.MultipleResultsError.html
+
+      iex> Accounts.get_user_by!(email: "brad@example.com")
 
   """
   def get_user_by!(params) do
-    # TODO: Don't return users where deleted_at is not nil
-    Repo.get_by!(User, params)
+    User
+    |> where([u], is_nil(u.deleted_at))
+    |> Repo.get_by!(params)
   end
 
   def get_user_by_password_reset_token(token) do
     get_user_by(password_reset_token_hash: Utils.Crypto.hash_token(token))
   end
-
-  # def get_user_by(username: username) do
-  #   TODO: Don't return users where deleted_at is not nil
-  #   Repo.one(
-  #     from u in User,
-  #     where: u.username == ^username
-  #   )
-  # end
 
   @doc """
   Creates a user.

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -28,7 +28,7 @@ root =
 Malan.Repo.insert!(root, on_conflict: :nothing, conflict_target: :username)
 
 # Promote root user to admin (currently the role gets stripped on create.  See #7)
-Accounts.get_user_by(username: "root")
+Accounts.get_user_by!(username: "root")
 |> Accounts.admin_update_user(%{roles: ["admin", "user"]})
 
 # ben = User.registration_changeset(%User{}, %{

--- a/test/malan/accounts_test.exs
+++ b/test/malan/accounts_test.exs
@@ -731,6 +731,79 @@ defmodule Malan.AccountsTest do
                )
     end
 
+    test "get_user_by/1" do
+      uf = user_fixture()
+
+      u1 = Accounts.get_user_by(username: uf.username)
+      assert %{uf | custom_attrs: %{}, password: nil} == u1
+
+      u2 = Accounts.get_user_by(email: uf.email)
+      assert %{uf | custom_attrs: %{}, password: nil} == u2
+
+      u3 = Accounts.get_user_by(last_name: uf.last_name)
+      assert %{uf | custom_attrs: %{}, password: nil} == u3
+
+      u4 = Accounts.get_user_by(first_name: uf.first_name)
+      assert %{uf | custom_attrs: %{}, password: nil} == u4
+
+      u5 = Accounts.get_user_by(first_name: "Not a real first name")
+      assert is_nil(u5)
+
+      assert u1 == u2
+      assert u1 == u3
+      assert u1 == u4
+    end
+
+    test "get_user_by/1 does not include deleted users" do
+      uf = user_fixture()
+
+      assert {:ok, %User{}} = Accounts.delete_user(uf)
+      assert_raise Ecto.NoResultsError, fn -> Accounts.get_user!(uf.id) end
+      assert is_nil(Accounts.get_user(uf.id))
+
+      assert Accounts.get_user_by(username: uf.username) |> is_nil()
+      assert Accounts.get_user_by(email: uf.email) |> is_nil()
+      assert Accounts.get_user_by(last_name: uf.last_name) |> is_nil()
+      assert Accounts.get_user_by(first_name: uf.first_name) |> is_nil()
+      assert Accounts.get_user_by(first_name: "Not a real first name") |> is_nil()
+    end
+
+    test "get_user_by!/1" do
+      uf = user_fixture()
+
+      u1 = Accounts.get_user_by!(username: uf.username)
+      assert %{uf | custom_attrs: %{}, password: nil} == u1
+
+      u2 = Accounts.get_user_by!(email: uf.email)
+      assert %{uf | custom_attrs: %{}, password: nil} == u2
+
+      u3 = Accounts.get_user_by!(last_name: uf.last_name)
+      assert %{uf | custom_attrs: %{}, password: nil} == u3
+
+      u4 = Accounts.get_user_by!(first_name: uf.first_name)
+      assert %{uf | custom_attrs: %{}, password: nil} == u4
+
+      assert u1 == u2
+      assert u1 == u3
+      assert u1 == u4
+
+      assert_raise Ecto.NoResultsError, fn -> Accounts.get_user_by!(first_name: "Not a real first name") end
+    end
+
+    test "get_user_by!/1 does not include deleted users" do
+      uf = user_fixture()
+
+      assert {:ok, %User{}} = Accounts.delete_user(uf)
+      assert_raise Ecto.NoResultsError, fn -> Accounts.get_user!(uf.id) end
+      assert is_nil(Accounts.get_user(uf.id))
+
+      assert_raise Ecto.NoResultsError, fn -> Accounts.get_user_by!(username: uf.username) end
+      assert_raise Ecto.NoResultsError, fn -> Accounts.get_user_by!(email: uf.email) end
+      assert_raise Ecto.NoResultsError, fn -> Accounts.get_user_by!(last_name: uf.last_name) end
+      assert_raise Ecto.NoResultsError, fn -> Accounts.get_user_by!(first_name: uf.first_name) end
+      assert_raise Ecto.NoResultsError, fn -> Accounts.get_user_by!(first_name: "Not a real first name") end
+    end
+
     test "get_user_by_password_reset_token/1" do
       # This is tested by the user controller test
     end
@@ -776,7 +849,7 @@ defmodule Malan.AccountsTest do
                id: ^user_id,
                email: "capitaladdr@example.com",
                username: "capitalusername"
-             } = Accounts.get_user_by(email: orig_email)
+             } = Accounts.get_user_by!(email: orig_email)
     end
 
     test "get_user_full/1 works" do


### PR DESCRIPTION
`#Accounts.get_user_by/1` and `#Accounts.get_user_by!/1` need to omit
results for "deleted" users.  This makes them do that and adds some
tests to verify.