### PR TITLE
Increase pool size for prod instances from 5 to 7

### DIFF
--- a/k8s/prod/deploy.yaml
+++ b/k8s/prod/deploy.yaml
@@ -90,7 +90,7 @@ metadata:
   namespace: malan-prod
 data:
   BIND_ADDR: '0.0.0.0'
-  POOL_SIZE: '5'
+  POOL_SIZE: '7'
   MAILGUN_DOMAIN: 'mg.accounts.ameelio.org'
   HOST: 'accounts.ameelio.org'
   PORT: '4000'


### PR DESCRIPTION
with 4 instances currently we are using 20 connections.  There are 47 / 97 connections still available during peak traffic.  This would increase us from 20 connections to 28, leaving 39 connections still unused.  I think it should be pretty safe and still leaves us with a lot of overhead in case of traffic bursts on other applications sharing the db