### PR TITLE
Add API for extending a session

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -31,9 +31,23 @@ config :malan, Malan.Config.RateLimits,
       "3" |> String.to_integer() # 1 per period
 
 config :malan, Malan.Accounts.Session,
-  # One week
+  # If client doesn't specify token expiration time, use this value.
+  # 604,800 seconds is 7 days (One week)
   default_token_expiration_secs:
-    System.get_env("DEFAULT_TOKEN_EXPIRATION_SECS") || "604800" |> String.to_integer()
+    System.get_env("DEFAULT_TOKEN_EXPIRATION_SECS") || "604800" |> String.to_integer(),
+  # If client doesn't specify session extension limit, use this value.  This will be
+  # used to determine an absolute maximum datetime beyond which a session cannot be extended
+  # 2,419,200 seconds is 28 days
+  default_max_extension_time_secs:
+    System.get_env("DEFAULT_MAX_EXTENSION_TIME_SECS") || "2419200" |> String.to_integer(),
+  # If client doesn't specify session extension limit per extension, use this value.
+  # 604,800 is 7 days (one week)
+  default_max_extension_secs:
+    System.get_env("DEFAULT_MAX_EXTENSION_SECS") || "604800" |> String.to_integer(),
+  # Most that a session can be extended, despite client settings.
+  # 7,862,400 is approximately 90 days (13 weeks specifically)
+  max_max_extension_secs:
+    System.get_env("MAX_MAX_EXTENSION_SECS") || "7862400" |> String.to_integer()
 
 # Configures the endpoint
 config :malan, MalanWeb.Endpoint,

--- a/lib/malan/accounts/session.ex
+++ b/lib/malan/accounts/session.ex
@@ -19,11 +19,28 @@ defmodule Malan.Accounts.Session do
     field :valid_only_for_ip, :boolean, default: false
     # This is not yet used but will be in #78
     field :valid_only_for_approved_ips, :boolean, default: false
+    # Absolute limit of extension.  Can never extend session beyond this point
+    field :extendable_until, :utc_datetime
+    # Longest a session can be extended for on each extension request
+    field :max_extension_secs, :integer
+    # field :auto_extend, :boolean, default: false
     belongs_to :user, User
+
+    embeds_many :extensions, Extension, on_replace: :raise do
+      @derive Jason.Encoder
+      field :old_expires_at, :utc_datetime
+      field :new_expires_at, :utc_datetime
+      field :extended_by_seconds, :integer
+      field :extended_by_user, :binary_id
+      field :extended_by_session, :binary_id
+      timestamps(type: :utc_datetime)
+    end
 
     field :api_token, :string, virtual: true
     field :never_expires, :boolean, virtual: true
     field :expires_in_seconds, :integer, virtual: true
+    field :extendable_until_seconds, :integer, virtual: true
+    field :extend_by_seconds, :integer, virtual: true
 
     timestamps(type: :utc_datetime)
   end
@@ -34,6 +51,8 @@ defmodule Malan.Accounts.Session do
     |> cast(attrs, [
       :api_token,
       :expires_at,
+      :extendable_until,
+      :max_extension_secs,
       :authenticated_at,
       :revoked_at,
       :ip_address,
@@ -42,8 +61,9 @@ defmodule Malan.Accounts.Session do
       :valid_only_for_approved_ips
     ])
     |> validate_required([
-      :api_token,
       :expires_at,
+      :extendable_until,
+      :max_extension_secs,
       :authenticated_at,
       :ip_address
     ])
@@ -56,6 +76,8 @@ defmodule Malan.Accounts.Session do
       :user_id,
       :never_expires,
       :expires_in_seconds,
+      :extendable_until_seconds,
+      :max_extension_secs,
       :ip_address,
       :location,
       :valid_only_for_ip,
@@ -63,9 +85,30 @@ defmodule Malan.Accounts.Session do
     ])
     |> put_api_token()
     |> set_expiration_time()
+    |> set_max_extension_time()
+    |> validate_max_extension_secs()
     |> put_authenticated_at()
-    |> validate_required([:api_token_hash, :expires_at, :authenticated_at, :ip_address])
+    |> validate_required([
+      :api_token_hash,
+      :expires_at,
+      :extendable_until,
+      :max_extension_secs,
+      :authenticated_at,
+      :ip_address
+    ])
+
     # |> validate_ip_addr(:ip_address)
+  end
+
+  @doc "Extend a user session"
+  def extend_changeset(session, attrs, authed_ids \\ %{}) do
+    session
+    |> cast(attrs, [:extend_by_seconds])
+    |> validate_extend_by_seconds()
+    |> validate_required([:extend_by_seconds])
+    |> validate_number(:extend_by_seconds, greater_than_or_equal_to: 0)
+    |> put_extension_expiration_time()
+    |> record_extension(authed_ids)
   end
 
   @doc "Revoke user session"
@@ -76,9 +119,28 @@ defmodule Malan.Accounts.Session do
       :revoked_at,
       :api_token_hash,
       :expires_at,
+      :extendable_until,
       :authenticated_at,
       :ip_address
     ])
+  end
+
+  def record_extension(changeset, authed_ids) do
+    new_extension_records =
+      prepend_new_extension_record(changeset, %{
+        old_expires_at: changeset.data.expires_at,
+        new_expires_at: get_change(changeset, :expires_at),
+        extended_by_seconds: get_field(changeset, :extend_by_seconds),
+        extended_by_user: Map.get(authed_ids, :authed_user_id, nil),
+        extended_by_session: Map.get(authed_ids, :authed_session_id)
+      })
+
+    changeset
+    |> put_embed(:extensions, new_extension_records)
+  end
+
+  defp prepend_new_extension_record(changeset, new_extension = %{}) do
+    [new_extension | changeset.data.extensions]
   end
 
   defp gen_api_token(), do: Utils.Crypto.strong_random_string(65)
@@ -133,8 +195,105 @@ defmodule Malan.Accounts.Session do
     set_expiration_time(changeset, num_weeks * 7, :days)
   end
 
+  # Default entrypoint for changeset pipeline
   defp set_expiration_time(changeset) do
     num_secs = Malan.Config.Session.default_token_expiration_secs()
+    # num_secs will be ignored if the changeset overrides the default
     set_expiration_time(changeset, num_secs, :seconds)
+  end
+
+  # Actually applies the change
+  defp set_max_extension_time(%Ecto.Changeset{} = changeset, %DateTime{} = date_time) do
+    put_change(changeset, :extendable_until, date_time)
+  end
+
+  # Default entrypoint when the max extension time is specified
+  defp set_max_extension_time(%{changes: %{extendable_until_seconds: ex_secs}} = changeset) do
+    case ex_secs <= Malan.Config.Session.max_max_extension_secs() do
+      true ->
+        set_max_extension_time(changeset, Utils.DateTime.adjust_cur_time_trunc(ex_secs, :seconds))
+
+      _ ->
+        set_max_extension_time(changeset, get_max_extension_time())
+    end
+  end
+
+  # Default entrypoint from changeset pipeline when no max extension time is specified
+  defp set_max_extension_time(changeset) do
+    changeset
+    |> put_change(
+      :extendable_until_seconds,
+      Malan.Config.Session.default_max_extension_time_secs()
+    )
+    |> set_max_extension_time()
+  end
+
+  defp get_max_extension_time() do
+    Utils.DateTime.adjust_cur_time_trunc(Malan.Config.Session.max_max_extension_secs(), :seconds)
+  end
+
+  # Function currently Unused.  Remove later if not needed
+  # defp get_default_max_extension_time() do
+  #   Utils.DateTime.adjust_cur_time_trunc(
+  #     Malan.Config.Session.default_max_extension_time_secs(),
+  #     :seconds
+  #   )
+  # end
+
+  defp validate_extend_by_seconds(changeset) do
+    max_extension_secs = get_field(changeset, :max_extension_secs)
+
+    case changeset do
+      %{changes: %{extend_by_seconds: extend_by_seconds}} ->
+        # Verify that we aren't exceeding the max_extension_secs that was set when this
+        # session was first created.  If we are, use the max value instead.
+        cond do
+          extend_by_seconds <= max_extension_secs -> changeset
+          true -> put_change(changeset, :extend_by_seconds, max_extension_secs)
+        end
+
+      _ ->
+        # User didn't specify an extension time, so use the default max
+        put_change(changeset, :extend_by_seconds, max_extension_secs)
+    end
+  end
+
+  defp put_extension_expiration_time(changeset) do
+    # Assign to variables for clarity (semantic meaning in variable name) and readability below
+    max_extension_date =
+      case get_field(changeset, :extendable_until) do
+        nil -> get_field(changeset, :expires_at)
+        extendable_until -> extendable_until
+      end
+
+    extend_by_seconds = get_change(changeset, :extend_by_seconds)
+
+    # Verify that we aren't exceeding the max extension time for this session.
+    # If we are, then just set the expiration time to the max extension time.
+    new_expiration_time = Utils.DateTime.adjust_cur_time_trunc(extend_by_seconds, :seconds)
+
+    new_expiration_time =
+      case DateTime.compare(new_expiration_time, max_extension_date) do
+        :lt -> new_expiration_time
+        :eq -> new_expiration_time
+        :gt -> max_extension_date
+      end
+
+    set_expiration_time(changeset, new_expiration_time)
+  end
+
+  defp validate_max_extension_secs(changeset) do
+    case changeset do
+      %Ecto.Changeset{changes: %{max_extension_secs: _}} ->
+        changeset
+
+      _ ->
+        put_change(
+          changeset,
+          :max_extension_secs,
+          Malan.Config.Session.default_max_extension_secs()
+        )
+    end
+    |> validate_number(:max_extension_secs, greater_than: 0)
   end
 end

--- a/lib/malan/config.ex
+++ b/lib/malan/config.ex
@@ -42,6 +42,24 @@ defmodule Malan.Config do
         :default_token_expiration_secs
       ]
     end
+
+    def default_max_extension_time_secs do
+      Application.get_env(:malan, Malan.Accounts.Session)[
+        :default_max_extension_time_secs
+      ]
+    end
+
+    def default_max_extension_secs do
+      Application.get_env(:malan, Malan.Accounts.Session)[
+        :default_max_extension_secs
+      ]
+    end
+
+    def max_max_extension_secs do
+      Application.get_env(:malan, Malan.Accounts.Session)[
+        :max_max_extension_secs
+      ]
+    end
   end
 
   defmodule User do

--- a/lib/malan/utils.ex
+++ b/lib/malan/utils.ex
@@ -884,6 +884,9 @@ defmodule Malan.Utils.DateTime do
   def utc_now_trunc(),
     do: DateTime.truncate(DateTime.utc_now(), :second)
 
+  def truncate(dt),
+    do: DateTime.truncate(dt, :second)
+
   @doc "Return a DateTime about 200 years into the future"
   def distant_future() do
     round(52.5 * 200 * 7 * 24 * 60 * 60)
@@ -972,6 +975,9 @@ defmodule Malan.Utils.DateTime do
 
   def expired?(expires_at),
     do: in_the_past?(expires_at, DateTime.utc_now())
+
+  def less_than_or_equal_to?(time1, time2),
+    do: DateTime.compare(time1, time2) != :gt
 end
 
 defmodule Malan.Utils.IPv4 do

--- a/lib/malan_web/router.ex
+++ b/lib/malan_web/router.ex
@@ -111,6 +111,7 @@ defmodule MalanWeb.Router do
     # Not piped through "owner" because no User ID is passed and it will only delete the current session
     get "/sessions/active", SessionController, :index_active
     get "/sessions/current", SessionController, :show_current
+    put "/sessions/current/extend", SessionController, :extend_current
     delete "/sessions/current", SessionController, :delete_current
 
     get "/logs", LogController, :user_index
@@ -123,6 +124,8 @@ defmodule MalanWeb.Router do
     resources "/users", UserController, only: [] do
       # Delete all active sessions for this user
       get "/sessions/active", SessionController, :user_index_active
+      put "/sessions/current/extend", SessionController, :extend_current
+      put "/sessions/:id/extend", SessionController, :extend
       delete "/sessions", SessionController, :delete_all
       resources "/sessions", SessionController, only: [:index, :show, :delete]
 

--- a/lib/malan_web/views/error_view.ex
+++ b/lib/malan_web/views/error_view.ex
@@ -53,6 +53,16 @@ defmodule MalanWeb.ErrorView do
     }
   end
 
+  def render("403.json", %{session_revoked_or_expired: true}) do
+    %{
+      ok: false,
+      code: 403,
+      detail: "Forbidden",
+      message: "Session cannot be extended.  It is expired or revoked",
+      errors: [%{session: ["revoked_or_expired: true"]}]
+    }
+  end
+
   def render("403.json", _assigns) do
     %{
       ok: false,

--- a/lib/malan_web/views/session_view.ex
+++ b/lib/malan_web/views/session_view.ex
@@ -25,7 +25,10 @@ defmodule MalanWeb.SessionView do
       valid_only_for_ip: session.valid_only_for_ip,
       valid_only_for_approved_ips: session.valid_only_for_approved_ips,
       location: session.location,
-      is_valid: Accounts.session_valid_bool?(session.expires_at, session.revoked_at)
+      is_valid: Accounts.session_valid_bool?(session.expires_at, session.revoked_at),
+      extendable_until: session.extendable_until,
+      max_extension_secs: session.max_extension_secs,
+      extensions: session.extensions
     }
     |> Enum.reject(fn {k, v} -> k == :api_token && is_nil(v) end)
     |> Enum.into(%{})

--- a/priv/repo/migrations/20230807195445_add_session_extension_columns_to_sessions.exs
+++ b/priv/repo/migrations/20230807195445_add_session_extension_columns_to_sessions.exs
@@ -1,0 +1,13 @@
+defmodule Malan.Repo.Migrations.AddSessionExtensionColumnsToSessions do
+  use Ecto.Migration
+
+  def change do
+    alter table(:sessions) do
+      add :extendable_until, :utc_datetime
+      add :max_extension_secs, :integer
+
+      # It is recommended to declare your embeds_many/3 field with type :map in your migrations, instead of using {:array, :map}. Ecto can work with both maps and arrays as the container for embeds (and in most databases maps are represented as JSON which allows Ecto to choose what works best).
+      add :extensions, :map
+    end
+  end
+end

--- a/test/malan/accounts_test.exs
+++ b/test/malan/accounts_test.exs
@@ -787,7 +787,9 @@ defmodule Malan.AccountsTest do
       assert u1 == u3
       assert u1 == u4
 
-      assert_raise Ecto.NoResultsError, fn -> Accounts.get_user_by!(first_name: "Not a real first name") end
+      assert_raise Ecto.NoResultsError, fn ->
+        Accounts.get_user_by!(first_name: "Not a real first name")
+      end
     end
 
     test "get_user_by!/1 does not include deleted users" do
@@ -801,7 +803,10 @@ defmodule Malan.AccountsTest do
       assert_raise Ecto.NoResultsError, fn -> Accounts.get_user_by!(email: uf.email) end
       assert_raise Ecto.NoResultsError, fn -> Accounts.get_user_by!(last_name: uf.last_name) end
       assert_raise Ecto.NoResultsError, fn -> Accounts.get_user_by!(first_name: uf.first_name) end
-      assert_raise Ecto.NoResultsError, fn -> Accounts.get_user_by!(first_name: "Not a real first name") end
+
+      assert_raise Ecto.NoResultsError, fn ->
+        Accounts.get_user_by!(first_name: "Not a real first name")
+      end
     end
 
     test "get_user_by_password_reset_token/1" do
@@ -1020,7 +1025,7 @@ defmodule Malan.AccountsTest do
     end
 
     test "list_sessions/2 returns all sessions" do
-      session = %{session_fixture() | api_token: nil}
+      session = %{session_fixture() | api_token: nil, extendable_until_seconds: nil}
       assert Accounts.list_sessions(0, 10) == [session]
       assert Accounts.list_sessions(1, 10) == []
     end
@@ -1078,7 +1083,12 @@ defmodule Malan.AccountsTest do
 
     test "get_session!/1 returns the session with given id" do
       session = session_fixture()
-      assert Accounts.get_session!(session.id) == %{session | api_token: nil}
+
+      assert Accounts.get_session!(session.id) == %{
+               session
+               | api_token: nil,
+                 extendable_until_seconds: nil
+             }
     end
 
     test "create_session/3 with valid data creates a session" do
@@ -1245,7 +1255,6 @@ defmodule Malan.AccountsTest do
 
     test "validate_session/2 returns a user id, roles, and expires_at when the session is valid" do
       session = session_fixture(%{"username" => "randomusername1"})
-      # TODO Unused
       assert {:ok, user_id, username, session_id, ip_address, valid_only_for_ip, roles, exp, tos,
               pp} = Accounts.validate_session(session.api_token, "1.1.1.1")
 
@@ -1550,6 +1559,392 @@ defmodule Malan.AccountsTest do
       session = Helpers.Accounts.set_expired(session)
       assert true == Accounts.session_expired?(session)
       assert true == Accounts.session_expired?(session.expires_at)
+    end
+
+    test "Creating a new session allows specifying max extension time" do
+      # Pass the max extension time to Accounts.create_session
+      session = session_fixture(%{}, %{"extendable_until_seconds" => 2 * 60 * 60})
+      expected_new_max_extension_time = Utils.DateTime.adjust_cur_time(2, :hours)
+
+      # Query fresh from the database and verify the new expiration time persisted properly
+      %Malan.Accounts.Session{extendable_until: extendable_until} =
+        Accounts.get_session!(session.id)
+
+      assert extendable_until == Utils.DateTime.truncate(expected_new_max_extension_time)
+    end
+
+    test "Creating a new session without specifying extension time uses default" do
+      session = session_fixture()
+
+      %Malan.Accounts.Session{max_extension_secs: max_extension_secs} =
+        Accounts.get_session!(session.id)
+
+      assert max_extension_secs == Malan.Config.Session.default_max_extension_secs()
+    end
+
+    test "Default max extension time works" do
+      # Pass the max extension time to Accounts.create_session
+      session = session_fixture()
+      expected_new_max_extension_time = Utils.DateTime.adjust_cur_time(4, :weeks)
+
+      # Query fresh from the database and verify the new expiration time persisted properly
+      %Malan.Accounts.Session{extendable_until: extendable_until} =
+        Accounts.get_session!(session.id)
+
+      assert TestUtils.DateTime.datetimes_within?(
+               expected_new_max_extension_time,
+               extendable_until,
+               2,
+               :seconds
+             )
+    end
+
+    test "Setting max extension time (for a new session) beyond the global maximum gets you the global maximum" do
+      # Pass the max extension time that exceeds our limit by 1 day (24 hours)
+      too_long_max_extension_secs = Malan.Config.Session.max_max_extension_secs() + 60 * 60 * 24
+
+      too_long_max_extension_time =
+        Utils.DateTime.adjust_cur_time(too_long_max_extension_secs, :seconds)
+
+      session =
+        session_fixture(%{}, %{
+          "extendable_until_seconds" => too_long_max_extension_secs,
+          "max_extension_seconds" => too_long_max_extension_secs
+        })
+
+      expected_new_max_extension_time = Utils.DateTime.adjust_cur_time(13, :weeks)
+
+      # Query fresh from the database and verify the new expiration time persisted properly
+      %Malan.Accounts.Session{extendable_until: extendable_until} =
+        Accounts.get_session!(session.id)
+
+      assert TestUtils.DateTime.datetimes_within?(
+               expected_new_max_extension_time,
+               extendable_until,
+               2,
+               :seconds
+             )
+
+      assert !TestUtils.DateTime.datetimes_within?(
+               too_long_max_extension_time,
+               extendable_until,
+               2,
+               :seconds
+             )
+    end
+
+    test "A session can be properly extended" do
+      # Initial session expires after 30 minutes
+      session = session_fixture(%{}, %{"expires_in_seconds" => 1800})
+      cur_exp_time = session.expires_at
+
+      assert TestUtils.DateTime.datetimes_within?(
+               cur_exp_time,
+               Utils.DateTime.adjust_cur_time(30, :minutes),
+               2,
+               :seconds
+             )
+
+      expected_new_exp_time = Utils.DateTime.adjust_cur_time(1, :hours)
+      assert {:ok, retval} = Accounts.extend_session(session, %{extend_by_seconds: 3600})
+
+      assert TestUtils.DateTime.datetimes_within?(
+               retval.expires_at,
+               expected_new_exp_time,
+               2,
+               :seconds
+             )
+
+      # Query fresh from the database and verify the new expiration time persisted properly
+      %Malan.Accounts.Session{expires_at: expires_at} = Accounts.get_session!(session.id)
+      assert TestUtils.DateTime.datetimes_within?(expires_at, expected_new_exp_time, 2, :seconds)
+    end
+
+    test "Trying to extend beyond the extendable_until point results in extension to that point" do
+      session = session_fixture(%{}, %{"expires_in_seconds" => 1800, "extendable_until_seconds" => 3600})
+      cur_exp_time = session.expires_at
+
+      assert TestUtils.DateTime.datetimes_within?(
+               cur_exp_time,
+               Utils.DateTime.adjust_cur_time(30, :minutes),
+               2,
+               :seconds
+             )
+
+      expected_new_exp_time = Utils.DateTime.adjust_cur_time(1, :hours)
+      # 2,000 seconds more than what should be allowed based on our limit set above
+      assert {:ok, retval} = Accounts.extend_session(session, %{extend_by_seconds: 5600})
+
+      assert TestUtils.DateTime.datetimes_within?(
+               retval.expires_at,
+               expected_new_exp_time,
+               2,
+               :seconds
+             )
+
+      # Query fresh from the database and verify the new expiration time persisted properly
+      %Malan.Accounts.Session{expires_at: expires_at} = Accounts.get_session!(session.id)
+      assert TestUtils.DateTime.datetimes_within?(expires_at, expected_new_exp_time, 2, :seconds)
+    end
+
+    test "Not specifying extension seconds defaults to the session max by default" do
+      # Initial session expires after 30 minutes
+      session = session_fixture()
+
+      assert TestUtils.DateTime.datetimes_within?(
+               session.expires_at,
+               Utils.DateTime.adjust_cur_time(session.max_extension_secs, :seconds),
+               2,
+               :seconds
+             )
+
+      expected_new_exp_time = Utils.DateTime.adjust_cur_time(1, :hours)
+      assert {:ok, retval} = Accounts.extend_session(session, %{extend_by_seconds: 3600})
+
+      assert TestUtils.DateTime.datetimes_within?(
+               retval.expires_at,
+               expected_new_exp_time,
+               2,
+               :seconds
+             )
+
+      # Query fresh from the database and verify the new expiration time persisted properly
+      %Malan.Accounts.Session{expires_at: expires_at} = Accounts.get_session!(session.id)
+      assert TestUtils.DateTime.datetimes_within?(expires_at, expected_new_exp_time, 2, :seconds)
+    end
+
+    test "A record of extensions is kept in the database" do
+      s1 =
+        session_fixture(%{}, %{
+          "expires_in_seconds" => 30,
+          "max_extension_secs" => 360,
+          "extendable_until_seconds" => 3600
+        })
+
+      user_id = s1.user_id
+      session_id = s1.id
+      expected_expiration_time_1 = Utils.DateTime.adjust_cur_time(30, :seconds)
+      expected_extendable_until_time = Utils.DateTime.adjust_cur_time(3600, :seconds)
+
+      assert s1.max_extension_secs == 360
+
+      assert TestUtils.DateTime.datetimes_within?(
+               s1.expires_at,
+               expected_expiration_time_1,
+               2,
+               :seconds
+             )
+
+      assert TestUtils.DateTime.datetimes_within?(
+               s1.extendable_until,
+               expected_extendable_until_time,
+               2,
+               :seconds
+             )
+
+      assert s1.extensions == []
+
+      # Extend the session by 1 minute
+      assert {:ok, s2} =
+               Accounts.extend_session(s1, %{extend_by_seconds: 60}, %{
+                 authed_user_id: user_id,
+                 authed_session_id: session_id
+               })
+
+      expected_expiration_time_2 = Utils.DateTime.adjust_cur_time(1, :minutes)
+
+      # max_extension_secs should stay the same after all extensions
+      assert s2.max_extension_secs == 360
+
+      assert TestUtils.DateTime.datetimes_within?(
+               s2.expires_at,
+               expected_expiration_time_2,
+               2,
+               :seconds
+             )
+
+      assert TestUtils.DateTime.datetimes_within?(
+               s2.extendable_until,
+               expected_extendable_until_time,
+               2,
+               :seconds
+             )
+
+      assert [
+               %Malan.Accounts.Session.Extension{
+                 updated_at: extension1_updated_at,
+                 inserted_at: extension1_inserted_at,
+                 extended_by_session: ^session_id,
+                 extended_by_user: ^user_id,
+                 extended_by_seconds: 60,
+                 new_expires_at: extension1_new_expires_at,
+                 old_expires_at: extension1_old_expires_at,
+                 id: extension1_id
+               }
+             ] = s2.extensions
+
+      assert extension1_new_expires_at == s2.expires_at
+
+      assert TestUtils.DateTime.datetimes_within?(
+               extension1_old_expires_at,
+               expected_expiration_time_1,
+               2,
+               :seconds
+             )
+
+      assert TestUtils.DateTime.datetimes_within?(
+               extension1_new_expires_at,
+               expected_expiration_time_2,
+               2,
+               :seconds
+             )
+
+      assert TestUtils.DateTime.within_last?(extension1_updated_at, 2, :seconds)
+      assert TestUtils.DateTime.within_last?(extension1_inserted_at, 2, :seconds)
+
+      # Extend the session a second time, by 2 minute
+      assert {:ok, s3} =
+               Accounts.extend_session(s2, %{extend_by_seconds: 120}, %{
+                 authed_user_id: user_id,
+                 authed_session_id: session_id
+               })
+
+      expected_expiration_time_3 = Utils.DateTime.adjust_cur_time(2, :minutes)
+
+      assert s3.max_extension_secs == 360
+
+      assert TestUtils.DateTime.datetimes_within?(
+               s3.expires_at,
+               expected_expiration_time_3,
+               2,
+               :seconds
+             )
+
+      assert TestUtils.DateTime.datetimes_within?(
+               s3.extendable_until,
+               expected_extendable_until_time,
+               2,
+               :seconds
+             )
+
+      assert [
+               %Malan.Accounts.Session.Extension{
+                 updated_at: extension2_updated_at,
+                 inserted_at: extension2_inserted_at,
+                 extended_by_session: ^session_id,
+                 extended_by_user: ^user_id,
+                 extended_by_seconds: 120,
+                 new_expires_at: extension2_new_expires_at,
+                 old_expires_at: extension2_old_expires_at,
+                 id: extension2_id
+               },
+               %Malan.Accounts.Session.Extension{
+                 updated_at: ^extension1_updated_at,
+                 inserted_at: ^extension1_inserted_at,
+                 extended_by_session: ^session_id,
+                 extended_by_user: ^user_id,
+                 extended_by_seconds: 60,
+                 new_expires_at: ^extension1_new_expires_at,
+                 old_expires_at: ^extension1_old_expires_at,
+                 id: ^extension1_id
+               }
+             ] = s3.extensions
+
+      assert extension2_new_expires_at == s3.expires_at
+
+      assert TestUtils.DateTime.datetimes_within?(
+               extension2_old_expires_at,
+               expected_expiration_time_2,
+               2,
+               :seconds
+             )
+
+      assert TestUtils.DateTime.datetimes_within?(
+               extension2_new_expires_at,
+               expected_expiration_time_3,
+               2,
+               :seconds
+             )
+
+      assert TestUtils.DateTime.within_last?(extension2_updated_at, 2, :seconds)
+      assert TestUtils.DateTime.within_last?(extension2_inserted_at, 2, :seconds)
+
+      # Extend the session a third time by 90 seconds
+      assert {:ok, s4} =
+               Accounts.extend_session(s3, %{extend_by_seconds: 90}, %{
+                 authed_user_id: user_id,
+                 authed_session_id: session_id
+               })
+
+      expected_expiration_time_4 = Utils.DateTime.adjust_cur_time(90, :seconds)
+
+      assert s4.max_extension_secs == 360
+
+      assert TestUtils.DateTime.datetimes_within?(
+               s4.expires_at,
+               expected_expiration_time_4,
+               2,
+               :seconds
+             )
+
+      assert TestUtils.DateTime.datetimes_within?(
+               s4.extendable_until,
+               expected_extendable_until_time,
+               2,
+               :seconds
+             )
+
+      assert [
+               %Malan.Accounts.Session.Extension{
+                 updated_at: extension3_updated_at,
+                 inserted_at: extension3_inserted_at,
+                 extended_by_session: ^session_id,
+                 extended_by_user: ^user_id,
+                 extended_by_seconds: 90,
+                 new_expires_at: extension3_new_expires_at,
+                 old_expires_at: extension3_old_expires_at,
+                 id: _extension3_id
+               },
+               %Malan.Accounts.Session.Extension{
+                 updated_at: ^extension2_updated_at,
+                 inserted_at: ^extension2_inserted_at,
+                 extended_by_session: ^session_id,
+                 extended_by_user: ^user_id,
+                 extended_by_seconds: 120,
+                 new_expires_at: ^extension2_new_expires_at,
+                 old_expires_at: ^extension2_old_expires_at,
+                 id: ^extension2_id
+               },
+               %Malan.Accounts.Session.Extension{
+                 updated_at: ^extension1_updated_at,
+                 inserted_at: ^extension1_inserted_at,
+                 extended_by_session: ^session_id,
+                 extended_by_user: ^user_id,
+                 extended_by_seconds: 60,
+                 new_expires_at: ^extension1_new_expires_at,
+                 old_expires_at: ^extension1_old_expires_at,
+                 id: ^extension1_id
+               }
+             ] = s4.extensions
+
+      assert extension3_new_expires_at == s4.expires_at
+
+      assert TestUtils.DateTime.datetimes_within?(
+               extension3_old_expires_at,
+               expected_expiration_time_3,
+               2,
+               :seconds
+             )
+
+      assert TestUtils.DateTime.datetimes_within?(
+               extension3_new_expires_at,
+               expected_expiration_time_4,
+               2,
+               :seconds
+             )
+
+      assert TestUtils.DateTime.within_last?(extension3_updated_at, 2, :seconds)
+      assert TestUtils.DateTime.within_last?(extension3_inserted_at, 2, :seconds)
     end
   end
 

--- a/test/malan_web/controllers/session_controller_test.exs
+++ b/test/malan_web/controllers/session_controller_test.exs
@@ -23,7 +23,9 @@ defmodule MalanWeb.SessionControllerTest do
     |> Utils.struct_to_map()
     |> Utils.map_atom_keys_to_strings()
     |> Enum.map(fn {k, v} -> {k, datetime_to_string(v)} end)
+    |> Enum.reject(fn {k, _v} -> k == "extendable_until_seconds" end)
     |> Enum.reject(fn {k, _v} -> k == "expires_in_seconds" end)
+    |> Enum.reject(fn {k, _v} -> k == "extend_by_seconds" end)
     |> Enum.reject(fn {k, _v} -> k == "api_token_hash" end)
     |> Enum.reject(fn {k, _v} -> k == "never_expires" end)
     |> Enum.reject(fn {k, _v} -> k == "inserted_at" end)
@@ -1072,6 +1074,140 @@ defmodule MalanWeb.SessionControllerTest do
                "message" => _
              } = json_response(conn, 403)
     end
+
+    test "Can specify maximum incremental session extension seconds and absolute limit", %{
+      conn: conn
+    } do
+      {:ok, user} = Helpers.Accounts.regular_user()
+      {:ok, user} = Helpers.Accounts.accept_user_tos_and_pp(user, true)
+      user_id = user.id
+
+      # Global absolute limit of extensions
+      extendable_until_seconds = 30
+      # Limit for each extension
+      max_extension_secs = 10
+
+      expected_extendable_until =
+        Utils.DateTime.adjust_cur_time_trunc(extendable_until_seconds, :seconds)
+
+      conn =
+        post(conn, Routes.session_path(conn, :create),
+          session: %{
+            username: user.username,
+            password: user.password,
+            extendable_until_seconds: extendable_until_seconds,
+            max_extension_secs: max_extension_secs
+          }
+        )
+
+      assert %{"id" => id, "api_token" => api_token, "max_extension_secs" => ^max_extension_secs} =
+               json_response(conn, 201)["data"]
+
+      conn = Helpers.Accounts.put_token(build_conn(), api_token)
+      conn = get(conn, Routes.user_session_path(conn, :show, user.id, id))
+
+      jr = json_response(conn, 200)["data"]
+
+      assert %{
+               "id" => ^id,
+               "user_id" => ^user_id,
+               "authenticated_at" => authenticated_at,
+               "expires_at" => expires_at,
+               "ip_address" => "127.0.0.1",
+               "location" => nil,
+               "revoked_at" => nil,
+               "is_valid" => true,
+               "valid_only_for_ip" => false,
+               "extendable_until" => actual_extendable_until,
+               "max_extension_secs" => ^max_extension_secs
+             } = jr
+
+      assert false == Map.has_key?(jr, "api_token")
+      {:ok, authenticated_at, 0} = DateTime.from_iso8601(authenticated_at)
+      {:ok, expires_at, 0} = DateTime.from_iso8601(expires_at)
+      {:ok, actual_extendable_until, 0} = DateTime.from_iso8601(actual_extendable_until)
+      assert TestUtils.DateTime.within_last?(authenticated_at, 5, :seconds) == true
+      assert Enum.member?(0..5, DateTime.diff(DateTime.utc_now(), authenticated_at, :second))
+
+      assert Enum.member?(
+               0..5,
+               DateTime.diff(Utils.DateTime.adjust_cur_time(1, :weeks), expires_at, :second)
+             )
+
+      assert TestUtils.DateTime.datetimes_within?(
+               actual_extendable_until,
+               expected_extendable_until,
+               2,
+               :seconds
+             )
+    end
+
+    test "Trying to exceed the global limit of session extension seconds results in the global limit",
+         %{conn: conn} do
+      {:ok, user} = Helpers.Accounts.regular_user()
+      {:ok, user} = Helpers.Accounts.accept_user_tos_and_pp(user, true)
+      user_id = user.id
+
+      extendable_until_seconds = Malan.Config.Session.max_max_extension_secs() + 30
+      max_extension_secs = extendable_until_seconds + 30
+
+      expected_extendable_until =
+        Utils.DateTime.adjust_cur_time_trunc(
+          Malan.Config.Session.max_max_extension_secs(),
+          :seconds
+        )
+
+      conn =
+        post(conn, Routes.session_path(conn, :create),
+          session: %{
+            username: user.username,
+            password: user.password,
+            extendable_until_seconds: extendable_until_seconds,
+            max_extension_secs: max_extension_secs
+          }
+        )
+
+      assert %{"id" => id, "api_token" => api_token, "max_extension_secs" => ^max_extension_secs} =
+               json_response(conn, 201)["data"]
+
+      conn = Helpers.Accounts.put_token(build_conn(), api_token)
+      conn = get(conn, Routes.user_session_path(conn, :show, user.id, id))
+
+      jr = json_response(conn, 200)["data"]
+
+      assert %{
+               "id" => ^id,
+               "user_id" => ^user_id,
+               "authenticated_at" => authenticated_at,
+               "expires_at" => expires_at,
+               "ip_address" => "127.0.0.1",
+               "location" => nil,
+               "revoked_at" => nil,
+               "is_valid" => true,
+               "valid_only_for_ip" => false,
+               "extendable_until" => actual_extendable_until,
+               "max_extension_secs" => ^max_extension_secs
+             } = jr
+
+      assert false == Map.has_key?(jr, "api_token")
+      {:ok, authenticated_at, 0} = DateTime.from_iso8601(authenticated_at)
+      {:ok, expires_at, 0} = DateTime.from_iso8601(expires_at)
+      {:ok, actual_extendable_until, 0} = DateTime.from_iso8601(actual_extendable_until)
+      assert TestUtils.DateTime.within_last?(authenticated_at, 5, :seconds) == true
+      assert Enum.member?(0..5, DateTime.diff(DateTime.utc_now(), authenticated_at, :second))
+
+      assert Enum.member?(
+               0..5,
+               DateTime.diff(Utils.DateTime.adjust_cur_time(1, :weeks), expires_at, :second)
+             )
+
+      assert TestUtils.DateTime.datetimes_within?(
+               actual_extendable_until,
+               expected_extendable_until,
+               2,
+               :seconds
+             )
+    end
   end
 
   describe "delete session" do
@@ -1382,6 +1518,875 @@ defmodule MalanWeb.SessionControllerTest do
       assert %Accounts.Session{revoked_at: ^s3_revoked_at} = Accounts.get_session!(s3.id)
       assert %Accounts.Session{revoked_at: ^s4_revoked_at} = Accounts.get_session!(s4.id)
       assert s1_revoked_at == s2_revoked_at
+    end
+  end
+
+  describe "extend user sessions" do
+    test "Session extension works (happy path) (IDs in path)", %{conn: conn} do
+      # Create the new session for the user
+      {:ok, user} = Helpers.Accounts.regular_user()
+      {:ok, user} = Helpers.Accounts.accept_user_tos_and_pp(user, true)
+      user_id = user.id
+
+      extendable_until_seconds = 90 # Global absolute limit of extensions
+      max_extension_secs = 45     # Limit for each extension
+
+      conn =
+        post(conn, Routes.session_path(conn, :create),
+          session: %{
+            username: user.username,
+            password: user.password,
+            extendable_until_seconds: extendable_until_seconds,
+            max_extension_secs: max_extension_secs
+          }
+        )
+
+      assert %{"id" => id, "api_token" => api_token, "max_extension_secs" => ^max_extension_secs} =
+               json_response(conn, 201)["data"]
+
+      # Reach under the hood and change the expiration time of the session
+      patched_expiration_time = Utils.DateTime.adjust_cur_time_trunc(15, :seconds)
+
+      assert {:ok, session} =
+               Accounts.get_session!(id)
+               |> Session.admin_changeset(%{expires_at: patched_expiration_time})
+               |> Malan.Repo.update()
+
+      assert session.expires_at == patched_expiration_time
+
+      # Now extend the session
+      expected_expires_at = Utils.DateTime.adjust_cur_time_trunc(30, :seconds)
+
+      conn = Helpers.Accounts.put_token(build_conn(), api_token)
+
+      conn =
+        put(conn, Routes.user_session_path(conn, :extend, user_id, id), %{extend_by_seconds: 30})
+
+      jr = json_response(conn, 200)["data"]
+
+      assert %{
+               "id" => ^id,
+               "user_id" => ^user_id,
+               "expires_at" => expires_at,
+               "is_valid" => true,
+               "max_extension_secs" => ^max_extension_secs
+             } = jr
+
+      {:ok, expires_at, 0} = DateTime.from_iso8601(expires_at)
+      assert TestUtils.DateTime.datetimes_within?(expires_at, expected_expires_at, 2, :seconds)
+
+      # Call the show endpoint and verify changes from above are persisted
+      conn = Helpers.Accounts.put_token(build_conn(), api_token)
+      conn = get(conn, Routes.user_session_path(conn, :show, user.id, id))
+
+      jr = json_response(conn, 200)["data"]
+
+      assert %{
+               "id" => ^id,
+               "user_id" => ^user_id,
+               "expires_at" => expires_at,
+               "is_valid" => true,
+               "max_extension_secs" => ^max_extension_secs
+             } = jr
+
+      {:ok, expires_at, 0} = DateTime.from_iso8601(expires_at)
+      assert TestUtils.DateTime.datetimes_within?(expires_at, expected_expires_at, 2, :seconds)
+    end
+
+    test "Session extension history gets recorded and surfaced to the user through the API", %{
+      conn: conn
+    } do
+      # Create the new session for the user
+      {:ok, user} = Helpers.Accounts.regular_user()
+      {:ok, user} = Helpers.Accounts.accept_user_tos_and_pp(user, true)
+      user_id = user.id
+
+      extendable_until_seconds = 360 # Global absolute limit of extensions
+      max_extension_secs = 300     # Limit for each extension
+
+      conn =
+        post(conn, Routes.session_path(conn, :create),
+          session: %{
+            username: user.username,
+            password: user.password,
+            extendable_until_seconds: extendable_until_seconds,
+            max_extension_secs: max_extension_secs
+          }
+        )
+
+      assert %{"id" => id, "api_token" => api_token, "max_extension_secs" => ^max_extension_secs} =
+               json_response(conn, 201)["data"]
+
+      # Reach under the hood and change the expiration time of the session
+      patched_expiration_time = Utils.DateTime.adjust_cur_time_trunc(15, :seconds)
+
+      assert {:ok, session} =
+               Accounts.get_session!(id)
+               |> Session.admin_changeset(%{expires_at: patched_expiration_time})
+               |> Malan.Repo.update()
+
+      assert session.expires_at == patched_expiration_time
+
+      # Now extend the session
+      expected_expires_at = Utils.DateTime.adjust_cur_time_trunc(30, :seconds)
+
+      conn = Helpers.Accounts.put_token(build_conn(), api_token)
+
+      conn =
+        put(conn, Routes.user_session_path(conn, :extend, user_id, id), %{extend_by_seconds: 30})
+
+      jr = json_response(conn, 200)["data"]
+
+      assert %{
+               "id" => ^id,
+               "user_id" => ^user_id,
+               "expires_at" => expires_at,
+               "is_valid" => true,
+               "max_extension_secs" => ^max_extension_secs,
+               "extensions" => [
+                 %{
+                   "id" => extension_1_id,
+                   "updated_at" => extension_1_updated_at,
+                   "inserted_at" => extension_1_inserted_at,
+                   "old_expires_at" => old_expires_at,
+                   "new_expires_at" => new_expires_at,
+                   "extended_by_user" => ^user_id,
+                   "extended_by_seconds" => 30,
+                   "extended_by_session" => ^id
+                 }
+               ]
+             } = jr
+
+      {:ok, expires_at, 0} = DateTime.from_iso8601(expires_at)
+      {:ok, new_expires_at_dt, 0} = DateTime.from_iso8601(new_expires_at)
+      {:ok, old_expires_at_dt, 0} = DateTime.from_iso8601(old_expires_at)
+      {:ok, extension_1_updated_at_dt, 0} = DateTime.from_iso8601(extension_1_updated_at)
+      {:ok, extension_1_inserted_at_dt, 0} = DateTime.from_iso8601(extension_1_inserted_at)
+      assert TestUtils.DateTime.datetimes_within?(expires_at, new_expires_at_dt, 1, :seconds)
+      assert TestUtils.DateTime.datetimes_within?(expires_at, expected_expires_at, 2, :seconds)
+
+      assert TestUtils.DateTime.datetimes_within?(
+               new_expires_at_dt,
+               expected_expires_at,
+               1,
+               :seconds
+             )
+
+      assert TestUtils.DateTime.datetimes_within?(
+               old_expires_at_dt,
+               patched_expiration_time,
+               1,
+               :seconds
+             )
+
+      assert TestUtils.DateTime.within_last?(extension_1_updated_at_dt, 2, :seconds)
+      assert TestUtils.DateTime.within_last?(extension_1_inserted_at_dt, 2, :seconds)
+
+      # Call the show endpoint and verify changes from above are persisted
+      conn = Helpers.Accounts.put_token(build_conn(), api_token)
+      conn = get(conn, Routes.user_session_path(conn, :show, user.id, id))
+
+      jr = json_response(conn, 200)["data"]
+
+      assert %{
+               "id" => ^id,
+               "user_id" => ^user_id,
+               "expires_at" => expires_at,
+               "is_valid" => true,
+               "max_extension_secs" => ^max_extension_secs,
+               "extensions" => [
+                 %{
+                   "id" => ^extension_1_id,
+                   "updated_at" => ^extension_1_updated_at,
+                   "inserted_at" => ^extension_1_inserted_at,
+                   "old_expires_at" => ^old_expires_at,
+                   "new_expires_at" => ^new_expires_at,
+                   "extended_by_user" => ^user_id,
+                   "extended_by_seconds" => 30,
+                   "extended_by_session" => ^id
+                 }
+               ]
+             } = jr
+
+      {:ok, expires_at, 0} = DateTime.from_iso8601(expires_at)
+      assert TestUtils.DateTime.datetimes_within?(expires_at, expected_expires_at, 2, :seconds)
+    end
+
+    test "Session extension works without args by using the default extension secs (and no IDs in path)",
+         %{conn: conn} do
+      # Create the new session for the user
+      {:ok, user} = Helpers.Accounts.regular_user()
+      {:ok, user} = Helpers.Accounts.accept_user_tos_and_pp(user, true)
+      user_id = user.id
+
+      extendable_until_seconds = 30 # Global absolute limit of extensions
+      max_extension_secs = 20     # Limit for each extension
+
+      conn =
+        post(conn, Routes.session_path(conn, :create),
+          session: %{
+            username: user.username,
+            password: user.password,
+            extendable_until_seconds: extendable_until_seconds,
+            max_extension_secs: max_extension_secs
+          }
+        )
+
+      assert %{"id" => id, "api_token" => api_token, "max_extension_secs" => ^max_extension_secs} =
+               json_response(conn, 201)["data"]
+
+      # Reach under the hood and change the expiration time of the session
+      patched_expiration_time = Utils.DateTime.adjust_cur_time_trunc(20, :seconds)
+
+      assert {:ok, session} =
+               Accounts.get_session!(id)
+               |> Session.admin_changeset(%{expires_at: patched_expiration_time})
+               |> Malan.Repo.update()
+
+      assert session.expires_at == patched_expiration_time
+
+      # Now extend the session
+      expected_expires_at = Utils.DateTime.adjust_cur_time_trunc(20, :seconds)
+
+      conn = Helpers.Accounts.put_token(build_conn(), api_token)
+      conn = put(conn, Routes.session_path(conn, :extend_current), %{extend_by_seconds: 20})
+
+      jr = json_response(conn, 200)["data"]
+
+      assert %{
+               "id" => ^id,
+               "user_id" => ^user_id,
+               "expires_at" => expires_at,
+               "is_valid" => true,
+               "max_extension_secs" => ^max_extension_secs
+             } = jr
+
+      {:ok, expires_at, 0} = DateTime.from_iso8601(expires_at)
+      assert TestUtils.DateTime.datetimes_within?(expires_at, expected_expires_at, 2, :seconds)
+
+      # Call the show endpoint and verify changes from above are persisted
+      conn = Helpers.Accounts.put_token(build_conn(), api_token)
+      conn = get(conn, Routes.user_session_path(conn, :show, user.id, id))
+
+      jr = json_response(conn, 200)["data"]
+
+      assert %{
+               "id" => ^id,
+               "user_id" => ^user_id,
+               "expires_at" => expires_at,
+               "is_valid" => true,
+               "max_extension_secs" => ^max_extension_secs
+             } = jr
+
+      {:ok, expires_at, 0} = DateTime.from_iso8601(expires_at)
+      assert TestUtils.DateTime.datetimes_within?(expires_at, expected_expires_at, 2, :seconds)
+    end
+
+    test "Extending requires authentication", %{conn: conn} do
+      conn = put(conn, Routes.session_path(conn, :extend_current), %{extend_by_seconds: 20})
+
+      assert %{
+               "ok" => false,
+               "code" => 403,
+               "detail" => "Forbidden",
+               "message" => _
+             } = json_response(conn, 403)
+
+      {:ok, user, session} = Helpers.Accounts.regular_user_with_session()
+
+      conn =
+        put(conn, Routes.user_session_path(conn, :extend, user.id, session.id), %{
+          extend_by_seconds: 30
+        })
+
+      assert %{
+               "ok" => false,
+               "code" => 403,
+               "detail" => "Forbidden",
+               "message" => _
+             } = json_response(conn, 403)
+    end
+
+    test "Extending requires ownership", %{conn: _conn} do
+      # Limit for each extension
+      max_extension_secs = 20
+
+      # Create the new session for the user
+      {:ok, c1, u1, s1} =
+        Helpers.Accounts.regular_user_session_conn(build_conn(), %{}, %{
+          "max_extension_secs" => max_extension_secs
+        })
+
+      {:ok, c2, _u2, s2} =
+        Helpers.Accounts.regular_user_session_conn(build_conn(), %{}, %{
+          "max_extension_secs" => max_extension_secs
+        })
+
+      {:ok, u1} = Helpers.Accounts.accept_user_tos_and_pp(u1, true)
+      u1_id = u1.id
+      s1_id = s1.id
+
+      # Reach under the hood and change the expiration time of the session
+      patched_expiration_time = Utils.DateTime.adjust_cur_time_trunc(5, :seconds)
+
+      assert {:ok, s1} =
+               Accounts.get_session!(s1.id)
+               |> Session.admin_changeset(%{expires_at: patched_expiration_time})
+               |> Malan.Repo.update()
+
+      assert {:ok, s2} =
+               Accounts.get_session!(s2.id)
+               |> Session.admin_changeset(%{expires_at: patched_expiration_time})
+               |> Malan.Repo.update()
+
+      assert s1.expires_at == patched_expiration_time
+      assert s2.expires_at == patched_expiration_time
+
+      # Now extend the session
+      c2 = put(c2, Routes.user_session_path(c2, :extend, u1.id, s1.id), %{extend_by_seconds: 20})
+
+      assert %{
+               "code" => 401,
+               "detail" => "Unauthorized",
+               "ok" => false
+             } = json_response(c2, 401)
+
+      # Call the show endpoint and verify changes from above are not persisted
+      c1 = get(c1, Routes.user_session_path(c1, :show, u1.id, s1.id))
+
+      jr = json_response(c1, 200)["data"]
+
+      assert %{
+               "id" => ^s1_id,
+               "user_id" => ^u1_id,
+               "expires_at" => expires_at,
+               "is_valid" => true,
+               "max_extension_secs" => ^max_extension_secs
+             } = jr
+
+      {:ok, expires_at, 0} = DateTime.from_iso8601(expires_at)
+
+      assert TestUtils.DateTime.datetimes_within?(
+               expires_at,
+               patched_expiration_time,
+               1,
+               :seconds
+             )
+    end
+
+    test "Attempts at extending after the token expires fails", %{conn: conn} do
+      # Create the new session for the user
+      {:ok, user} = Helpers.Accounts.regular_user()
+      {:ok, user} = Helpers.Accounts.accept_user_tos_and_pp(user, true)
+      user_id = user.id
+
+      extendable_until_seconds = 30 # Global absolute limit of extensions
+      max_extension_secs = 20     # Limit for each extension
+
+      conn =
+        post(conn, Routes.session_path(conn, :create),
+          session: %{
+            username: user.username,
+            password: user.password,
+            extendable_until_seconds: extendable_until_seconds,
+            max_extension_secs: max_extension_secs
+          }
+        )
+
+      assert %{"id" => id, "api_token" => api_token, "max_extension_secs" => ^max_extension_secs} =
+               json_response(conn, 201)["data"]
+
+      # Reach under the hood and change the expiration time of the session
+      patched_expiration_time = Utils.DateTime.adjust_cur_time_trunc(-20, :seconds)
+
+      assert {:ok, session} =
+               Accounts.get_session!(id)
+               |> Session.admin_changeset(%{expires_at: patched_expiration_time})
+               |> Malan.Repo.update()
+
+      assert session.expires_at == patched_expiration_time
+
+      assert Helpers.Accounts.session_valid?(id) == false
+      assert Helpers.Accounts.session_valid?(session) == false
+
+      # Now try to extend the session
+      conn = Helpers.Accounts.put_token(build_conn(), api_token)
+      conn = put(conn, Routes.session_path(conn, :extend_current), %{extend_by_seconds: 20})
+
+      assert %{
+               "code" => 403,
+               "detail" => "Forbidden",
+               "ok" => false,
+               "token_expired" => true
+             } = json_response(conn, 403)
+
+      # Ensure we can't do a show either with this token
+      conn = Helpers.Accounts.put_token(build_conn(), api_token)
+      conn = get(conn, Routes.user_session_path(conn, :show, user.id, id))
+
+      assert %{
+               "code" => 403,
+               "detail" => "Forbidden",
+               "ok" => false,
+               "token_expired" => true
+             } = json_response(conn, 403)
+
+      # Call the show endpoint with a different token and verify session is still expired
+      {:ok, conn, _au1, _su1} = Helpers.Accounts.admin_user_session_conn(build_conn())
+      conn = get(conn, Routes.user_session_path(conn, :show, user.id, id))
+
+      jr = json_response(conn, 200)["data"]
+
+      assert %{
+               "id" => ^id,
+               "user_id" => ^user_id,
+               "expires_at" => expires_at,
+               "is_valid" => false,
+               "max_extension_secs" => ^max_extension_secs
+             } = jr
+
+      {:ok, expires_at, 0} = DateTime.from_iso8601(expires_at)
+
+      assert TestUtils.DateTime.datetimes_within?(
+               expires_at,
+               patched_expiration_time,
+               2,
+               :seconds
+             )
+    end
+
+    test "Does not change previously closed sessions", %{conn: _conn} do
+      #
+      # Create two sessions for a user.  Expire one and use the second to extend the first.  It should fail
+      #
+
+      # Create the new sessions for the user
+      {:ok, _c1, user, s1} = Helpers.Accounts.regular_user_session_conn(build_conn())
+      {:ok, c2, s2} = Helpers.Accounts.create_session_conn(build_conn(), user)
+      {:ok, user} = Helpers.Accounts.accept_user_tos_and_pp(user, true)
+      user_id = user.id
+      s1_id = s1.id
+
+      # Reach under the hood and change the expiration time of the first session
+      patched_expiration_time = Utils.DateTime.adjust_cur_time_trunc(-20, :seconds)
+
+      assert {:ok, s1} =
+               Accounts.get_session!(s1.id)
+               |> Session.admin_changeset(%{expires_at: patched_expiration_time})
+               |> Malan.Repo.update()
+
+      assert s1.expires_at == patched_expiration_time
+      assert s2.expires_at != patched_expiration_time
+
+      assert Helpers.Accounts.session_valid?(s1) == false
+      assert Helpers.Accounts.session_valid?(s2) == true
+
+      # Now extend the session
+      c2 =
+        put(c2, Routes.user_session_path(c2, :extend, user.id, s1.id), %{extend_by_seconds: 20})
+
+      assert %{
+               "code" => 403,
+               "detail" => "Forbidden",
+               "ok" => false
+             } = json_response(c2, 403)
+
+      # Call the show endpoint and verify changes to s1 didn't take affect
+      {:ok, conn, _au1, _su1} = Helpers.Accounts.admin_user_session_conn(build_conn())
+      conn = get(conn, Routes.user_session_path(conn, :show, user.id, s1.id))
+
+      assert %{
+               "id" => ^s1_id,
+               "user_id" => ^user_id,
+               "expires_at" => expires_at,
+               "is_valid" => false
+             } = json_response(conn, 200)["data"]
+
+      {:ok, expires_at, 0} = DateTime.from_iso8601(expires_at)
+
+      assert TestUtils.DateTime.datetimes_within?(
+               expires_at,
+               patched_expiration_time,
+               1,
+               :seconds
+             )
+    end
+
+    test "Admins can extend regular user sessions", %{conn: _conn} do
+      # TODO EXTENSION
+    end
+
+    test "Admins can extend regular sessions", %{conn: _conn} do
+      # TODO EXTENSION
+    end
+
+    test "Revoking a session makes it so it can't be extended even if not expired", %{conn: _conn} do
+      #
+      # Create two sessions for a user.  Revoke the first one and use the second to extend the first.
+      # It should fail
+      #
+
+      # Create the new sessions for the user
+      {:ok, _c1, user, s1} = Helpers.Accounts.regular_user_session_conn(build_conn())
+      {:ok, c2, s2} = Helpers.Accounts.create_session_conn(build_conn(), user)
+      {:ok, user} = Helpers.Accounts.accept_user_tos_and_pp(user, true)
+      user_id = user.id
+      s1_id = s1.id
+
+      assert Accounts.session_revoked_or_expired?(s1) == false
+      assert Helpers.Accounts.session_revoked_or_expired?(s1_id) == false
+      assert Accounts.session_revoked?(s1) == false
+      assert Accounts.session_expired?(s1) == false
+
+      # Revoke the first session
+      c2 = delete(c2, Routes.user_session_path(c2, :delete, user.id, s1.id))
+
+      assert %{
+               "id" => ^s1_id,
+               "user_id" => ^user_id,
+               "revoked_at" => revoked_at,
+               "is_valid" => false
+             } = json_response(c2, 200)["data"]
+
+      {:ok, revoked_at, 0} = revoked_at |> DateTime.from_iso8601()
+      assert TestUtils.DateTime.within_last?(revoked_at, 2, :seconds) == true
+
+      s1 = Accounts.get_session!(s1.id)
+      assert Accounts.session_revoked_or_expired?(s1) == true
+      assert Helpers.Accounts.session_revoked_or_expired?(s1_id) == true
+      assert Accounts.session_revoked?(s1) == true
+      assert Accounts.session_expired?(s1) == false
+
+      # Now try to extend the session
+      c2 = Helpers.Accounts.put_token(build_conn(), s2.api_token)
+
+      c2 =
+        put(c2, Routes.user_session_path(c2, :extend, user.id, s1.id), %{extend_by_seconds: 20})
+
+      assert %{
+               "code" => 403,
+               "detail" => "Forbidden",
+               "ok" => false
+             } = json_response(c2, 403)
+
+      # Call the show endpoint and verify changes to s1 didn't take affect
+      {:ok, conn, _au1, _su1} = Helpers.Accounts.admin_user_session_conn(build_conn())
+      conn = get(conn, Routes.user_session_path(conn, :show, user.id, s1.id))
+
+      assert %{
+               "id" => ^s1_id,
+               "user_id" => ^user_id,
+               "expires_at" => expires_at,
+               "revoked_at" => revoked_at,
+               "is_valid" => false
+             } = json_response(conn, 200)["data"]
+
+      {:ok, expires_at, 0} = DateTime.from_iso8601(expires_at)
+      {:ok, revoked_at, 0} = DateTime.from_iso8601(revoked_at)
+
+      assert TestUtils.DateTime.datetimes_within?(
+               expires_at,
+               s1.expires_at,
+               1,
+               :seconds
+             )
+
+      assert TestUtils.DateTime.within_last?(revoked_at, 2, :seconds) == true
+      assert Accounts.session_revoked_or_expired?(s1) == true
+      assert Accounts.session_revoked?(s1) == true
+      assert Accounts.session_expired?(s1) == false
+    end
+
+    test "Revoking an extended session terminates the session immediately", %{conn: conn} do
+      # Create the new session for the user
+      {:ok, user} = Helpers.Accounts.regular_user()
+      {:ok, user} = Helpers.Accounts.accept_user_tos_and_pp(user, true)
+      user_id = user.id
+
+      extendable_until_seconds = 90 # Global absolute limit of extensions
+      max_extension_secs = 45     # Limit for each extension
+      extension_secs = 30
+
+      conn =
+        post(conn, Routes.session_path(conn, :create),
+          session: %{
+            username: user.username,
+            password: user.password,
+            extendable_until_seconds: extendable_until_seconds,
+            max_extension_secs: max_extension_secs
+          }
+        )
+
+      assert %{
+               "id" => id,
+               "api_token" => api_token,
+               "max_extension_secs" => ^max_extension_secs,
+               "expires_at" => _orig_expires_at
+             } = json_response(conn, 201)["data"]
+
+      # Reach under the hood and change the expiration time of the session
+      patched_expiration_time = Utils.DateTime.adjust_cur_time_trunc(45, :seconds)
+
+      assert {:ok, session} =
+               Accounts.get_session!(id)
+               |> Session.admin_changeset(%{expires_at: patched_expiration_time})
+               |> Malan.Repo.update()
+
+      assert session.expires_at == patched_expiration_time
+
+      # Now extend the session
+      expected_expires_at = Utils.DateTime.adjust_cur_time_trunc(extension_secs, :seconds)
+
+      conn = Helpers.Accounts.put_token(build_conn(), api_token)
+
+      conn =
+        put(conn, Routes.user_session_path(conn, :extend, user_id, id), %{
+          extend_by_seconds: extension_secs
+        })
+
+      jr = json_response(conn, 200)["data"]
+
+      assert %{
+               "id" => ^id,
+               "user_id" => ^user_id,
+               "expires_at" => expires_at,
+               "is_valid" => true,
+               "max_extension_secs" => ^max_extension_secs
+             } = jr
+
+      {:ok, expires_at, 0} = DateTime.from_iso8601(expires_at)
+      assert TestUtils.DateTime.datetimes_within?(expires_at, expected_expires_at, 2, :seconds)
+
+      # Call the show endpoint and verify changes from above are persisted
+      conn = Helpers.Accounts.put_token(build_conn(), api_token)
+      conn = get(conn, Routes.user_session_path(conn, :show, user.id, id))
+
+      jr = json_response(conn, 200)["data"]
+
+      assert %{
+               "id" => ^id,
+               "user_id" => ^user_id,
+               "expires_at" => expires_at,
+               "is_valid" => true,
+               "max_extension_secs" => ^max_extension_secs
+             } = jr
+
+      {:ok, expires_at, 0} = DateTime.from_iso8601(expires_at)
+      assert TestUtils.DateTime.datetimes_within?(expires_at, expected_expires_at, 2, :seconds)
+
+      # Now revoke the session
+      conn = delete(conn, Routes.user_session_path(conn, :delete, user.id, id))
+
+      assert %{
+               "id" => ^id,
+               "user_id" => ^user_id,
+               "revoked_at" => revoked_at,
+               "is_valid" => false
+             } = json_response(conn, 200)["data"]
+
+      {:ok, revoked_at, 0} = revoked_at |> DateTime.from_iso8601()
+      assert TestUtils.DateTime.within_last?(revoked_at, 2, :seconds) == true
+
+      assert Helpers.Accounts.session_revoked_or_expired?(id) == true
+      assert Helpers.Accounts.session_revoked?(id) == true
+      assert Helpers.Accounts.session_expired?(id) == false
+
+      # Call the show endpoint and verify session is revoked
+      conn = Helpers.Accounts.put_token(build_conn(), api_token)
+      conn = get(conn, Routes.user_session_path(conn, :show, user.id, id))
+
+      assert %{
+               "code" => 403,
+               "detail" => "Forbidden",
+               "ok" => false,
+               "token_expired" => true
+             } = json_response(conn, 403)
+
+      # Triple verify with admin token
+      {:ok, conn, _au1, _su1} = Helpers.Accounts.admin_user_session_conn(build_conn())
+      conn = get(conn, Routes.user_session_path(conn, :show, user.id, id))
+
+      assert %{
+               "id" => ^id,
+               "user_id" => ^user_id,
+               "expires_at" => expires_at,
+               "revoked_at" => revoked_at,
+               "is_valid" => false
+             } = json_response(conn, 200)["data"]
+
+      {:ok, expires_at, 0} = DateTime.from_iso8601(expires_at)
+      {:ok, revoked_at, 0} = DateTime.from_iso8601(revoked_at)
+
+      assert TestUtils.DateTime.datetimes_within?(expires_at, expected_expires_at, 2, :seconds)
+
+      assert TestUtils.DateTime.within_last?(revoked_at, 2, :seconds) == true
+      assert Helpers.Accounts.session_revoked_or_expired?(id) == true
+      assert Helpers.Accounts.session_revoked?(id) == true
+      assert Helpers.Accounts.session_expired?(id) == false
+    end
+
+    test "Extending a session with less time than it has expiration changes the expiration down to match extension",
+         %{conn: conn} do
+      # Create the new session for the user
+      {:ok, user} = Helpers.Accounts.regular_user()
+      {:ok, user} = Helpers.Accounts.accept_user_tos_and_pp(user, true)
+      user_id = user.id
+
+      extendable_until_seconds = 90 # Global absolute limit of extensions
+      max_extension_secs = 45     # Limit for each extension
+      extension_secs = 30
+
+      conn =
+        post(conn, Routes.session_path(conn, :create),
+          session: %{
+            username: user.username,
+            password: user.password,
+            extendable_until_seconds: extendable_until_seconds,
+            max_extension_secs: max_extension_secs
+          }
+        )
+
+      assert %{
+               "id" => id,
+               "api_token" => api_token,
+               "max_extension_secs" => ^max_extension_secs,
+               "expires_at" => _orig_expires_at
+             } = json_response(conn, 201)["data"]
+
+      # Reach under the hood and change the expiration time of the session
+      patched_expiration_time = Utils.DateTime.adjust_cur_time_trunc(45, :seconds)
+
+      assert {:ok, session} =
+               Accounts.get_session!(id)
+               |> Session.admin_changeset(%{expires_at: patched_expiration_time})
+               |> Malan.Repo.update()
+
+      assert session.expires_at == patched_expiration_time
+
+      # Now extend the session
+      expected_expires_at = Utils.DateTime.adjust_cur_time_trunc(extension_secs, :seconds)
+
+      conn = Helpers.Accounts.put_token(build_conn(), api_token)
+
+      conn =
+        put(conn, Routes.user_session_path(conn, :extend, user_id, id), %{
+          extend_by_seconds: extension_secs
+        })
+
+      jr = json_response(conn, 200)["data"]
+
+      assert %{
+               "id" => ^id,
+               "user_id" => ^user_id,
+               "expires_at" => expires_at,
+               "is_valid" => true,
+               "max_extension_secs" => ^max_extension_secs
+             } = jr
+
+      {:ok, expires_at, 0} = DateTime.from_iso8601(expires_at)
+      assert TestUtils.DateTime.datetimes_within?(expires_at, expected_expires_at, 2, :seconds)
+
+      # Call the show endpoint and verify session expiration has changed to match extension
+      conn = Helpers.Accounts.put_token(build_conn(), api_token)
+      conn = get(conn, Routes.user_session_path(conn, :show, user.id, id))
+
+      assert %{
+               "id" => ^id,
+               "user_id" => ^user_id,
+               "expires_at" => expires_at,
+               "revoked_at" => nil,
+               "is_valid" => true
+             } = json_response(conn, 200)["data"]
+
+      {:ok, expires_at, 0} = DateTime.from_iso8601(expires_at)
+
+      assert TestUtils.DateTime.datetimes_within?(expires_at, expected_expires_at, 2, :seconds)
+
+      assert Helpers.Accounts.session_revoked_or_expired?(id) == false
+      assert Helpers.Accounts.session_revoked?(id) == false
+      assert Helpers.Accounts.session_expired?(id) == false
+    end
+
+    test "Extending a session generates a log", %{conn: _conn} do
+      # TODO EXTENSION
+    end
+
+    test "Existing sessions (without the new extension attrs) can't be extended but don't error",
+         %{conn: _conn} do
+      # Create the new session for the user
+      {:ok, user, session} = Helpers.Accounts.regular_user_with_session()
+      user_id = user.id
+      session_id = session.id
+      api_token = session.api_token
+
+      # Reach under the hood and change the session attrs to match previously existing sessions
+      patched_expiration_time = Utils.DateTime.adjust_cur_time_trunc(45, :seconds)
+
+      assert {:ok, session} =
+               Accounts.get_session!(session_id)
+               |> Ecto.Changeset.change(%{
+                 extendable_until: nil,
+                 max_extension_secs: nil,
+                 expires_at: patched_expiration_time
+               })
+               |> Malan.Repo.update()
+
+      assert is_nil(session.extendable_until)
+      assert is_nil(session.max_extension_secs)
+      assert session.expires_at == patched_expiration_time
+
+      # Now try extend the session
+      conn = Helpers.Accounts.put_token(build_conn(), api_token)
+
+      conn =
+        put(conn, Routes.user_session_path(conn, :extend, user_id, session_id), %{
+          extend_by_seconds: 180
+        })
+
+      jr = json_response(conn, 200)["data"]
+
+      assert %{
+               "id" => ^session_id,
+               "user_id" => ^user_id,
+               "expires_at" => expires_at,
+               "is_valid" => true,
+               "max_extension_secs" => nil
+             } = jr
+
+      {:ok, expires_at, 0} = DateTime.from_iso8601(expires_at)
+
+      assert TestUtils.DateTime.datetimes_within?(
+               expires_at,
+               patched_expiration_time,
+               2,
+               :seconds
+             )
+
+      # Call the show endpoint and verify nothing above changed and the show endpoint doesn't choke
+      # on the missing attrs
+      conn = Helpers.Accounts.put_token(build_conn(), api_token)
+      conn = get(conn, Routes.user_session_path(conn, :show, user.id, session_id))
+
+      jr = json_response(conn, 200)["data"]
+
+      assert %{
+               "id" => ^session_id,
+               "user_id" => ^user_id,
+               "expires_at" => expires_at,
+               "is_valid" => true,
+               "revoked_at" => nil,
+               "extendable_until" => nil,
+               "max_extension_secs" => nil
+             } = jr
+
+      {:ok, expires_at, 0} = DateTime.from_iso8601(expires_at)
+
+      assert TestUtils.DateTime.datetimes_within?(
+               expires_at,
+               patched_expiration_time,
+               2,
+               :seconds
+             )
     end
   end
 

--- a/test/support/helpers/accounts.ex
+++ b/test/support/helpers/accounts.ex
@@ -251,9 +251,10 @@ defmodule Malan.Test.Helpers.Accounts do
   end
 
   def set_expires_at(session, expires_at) do
-    {:ok, session} = session
-    |> Session.admin_changeset(%{expires_at: expires_at})
-    |> Repo.update()
+    {:ok, session} =
+      session
+      |> Session.admin_changeset(%{expires_at: expires_at})
+      |> Repo.update()
 
     session
   end
@@ -266,5 +267,29 @@ defmodule Malan.Test.Helpers.Accounts do
   def set_revoked_at(session, revoked_at) do
     {:ok, session} = Accounts.revoke_session_at(session, revoked_at)
     session
+  end
+
+  def session_valid?(id) when is_binary(id) do
+    Accounts.get_session!(id)
+    |> session_valid?()
+  end
+
+  def session_valid?(session) do
+    Accounts.session_valid_bool?(session.expires_at, session.revoked_at)
+  end
+
+  def session_revoked?(id) when is_binary(id) do
+    Accounts.get_session!(id)
+    |> Accounts.session_revoked?()
+  end
+
+  def session_expired?(id) when is_binary(id) do
+    Accounts.get_session!(id)
+    |> Accounts.session_expired?()
+  end
+
+  def session_revoked_or_expired?(session_id) when is_binary(session_id) do
+    Accounts.get_session!(session_id)
+    |> Accounts.session_revoked_or_expired?()
   end
 end

--- a/test/support/test_utils.ex
+++ b/test/support/test_utils.ex
@@ -77,6 +77,21 @@ defmodule Malan.Test.Utils.DateTime do
   def first_after_second_within?(dt1, dt2, num, :weeks),
     do: first_after_second_within?(dt1, dt2, num * 7, :days)
 
+  def datetimes_within?(dt1, dt2, num, :seconds),
+    do: inner_compare(dt1, dt2, Range.new(0, num))
+
+  def datetimes_within?(dt1, dt2, num, :minutes),
+    do: datetimes_within?(dt1, dt2, num * 60, :seconds)
+
+  def datetimes_within?(dt1, dt2, num, :hours),
+    do: datetimes_within?(dt1, dt2, num * 60, :minutes)
+
+  def datetimes_within?(dt1, dt2, num, :days),
+    do: datetimes_within?(dt1, dt2, num * 24, :hours)
+
+  def datetimes_within?(dt1, dt2, num, :weeks),
+    do: datetimes_within?(dt1, dt2, num * 7, :days)
+
   @doc ~S"""
   Check if the specified datetime references a time within the last `num` of units
   """


### PR DESCRIPTION
While a session is still active, it can be extended up to the limit specified at session creation time.  Extensions can be done using the existing token by calling one of the new endpoints:

```
PUT /sessions/current/extend
PUT /users/:id/sessions/:id/extend
```

You can omit the body, or include it with specification of how long to extend the session for.  Example, this body in a
`PUT /sessins/current/extend`:

```json
{
  "extend_by_seconds": 300
}
```

Extensions are logged as JSON objects in the Session object for auditing purposes.  These are returned as part of the show (GET) endpoint for Sessions

GET /sessions/current
GET /users/:id/sessions/:id

Some of the tests have been stubbed but are not yet completed.

New parameters in the Session object (these show up in the GET responses now):

`extendable_until` (datetime) - UTC DateTime of the last point in time that a session can be alive.  You can't extend past this point.  This is configured in the create (POST) action that first created the session. This is set through the session parameter in the JSON called `extendable_until_seconds`.  If not explicitly set, a default value will be used.

`max_extension_secs` (integer) - This is the farthest into the future an extension can go.  This is also configured at session creation time using the "max_extension_secs" field in the session JSON.  If left empty, a default value will be used.

`extensions` (Array  of Session Extension objects) - This is a record of each extension that has been made to the session object.  They are in reverse order (for performance reasons), so the last one in the Array is actually the first extension that was made.