### PR TITLE
allow deleting sessions without extendable_until

### DIFF
--- a/lib/malan/accounts/session.ex
+++ b/lib/malan/accounts/session.ex
@@ -110,7 +110,6 @@ defmodule Malan.Accounts.Session do
       :revoked_at,
       :api_token_hash,
       :expires_at,
-      :extendable_until,
       :authenticated_at,
       :ip_address
     ])


### PR DESCRIPTION
I observed this error from a session that likely predated the extension rollout:

> #SessionController.delete/2 - Session deletion failed: extendable_until: can’t be blank

I'm not aware of way that `extendable_until` relates to session deletion, so I am proposing that it not be required.