### PR TITLE
Allow runtime setting of log level

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -17,7 +17,4 @@ config :malan, MalanWeb.Endpoint,
     "https://accounts.ameelio.org"
   ]
 
-# Do not print debug messages in production
-config :logger, level: :info
-
 config :malan, :sentry, enabled: true

--- a/config/test.exs
+++ b/config/test.exs
@@ -28,9 +28,6 @@ config :malan, MalanWeb.Endpoint,
 # In test we don't send emails.
 config :malan, Malan.Mailer, adapter: Swoosh.Adapters.Test
 
-# Print only warnings and errors during test
-config :logger, level: :warning
-
 # Initialize plugs at runtime for faster test compilation
 config :phoenix, :plug_init_mode, :runtime
 

--- a/docker-compose-example.yml
+++ b/docker-compose-example.yml
@@ -19,6 +19,7 @@ services:
       DB_PASSWORD: 'postgres'
       DB_HOSTNAME: 'postgres'
       BIND_ADDR: '0.0.0.0'
+      LOG_LEVEL: 'debug'
     depends_on:
       - 'postgres'
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       DB_USERNAME: 'postgres'
       DB_PASSWORD: 'postgres'
       DB_HOSTNAME: 'postgres'
+      LOG_LEVEL: 'debug'
     depends_on:
       - 'postgres'
 


### PR DESCRIPTION
This change allows an env var of LOG_LEVEL to be set to a valid log level to override the default for the environment.  Prior behavior will remain the same unless LOG_LEVEL is set to a non-empty value