### PR TITLE
JR/add apple app site association entry for Connect mobile staging

### DIFF
--- a/priv/static/.well-known/apple-app-site-association
+++ b/priv/static/.well-known/apple-app-site-association
@@ -7,6 +7,12 @@
         "paths": [
            "/users/reset_password/*"
         ]
+      },
+      {
+        "appID": "88S25855SR.com.ameelio.connect.staging",
+        "paths": [
+           "/users/reset_password/*"
+        ]
       }
     ]
   }


### PR DESCRIPTION
This PR adds an entry in the `details` array for the Apple app site association file.