### PR TITLE
Fix three Sentry error clusters: LogWriter changeset crashes, Postgres SSL idle drops, DB config

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -351,6 +351,15 @@ if config_env() == :prod do
 
   maybe_ipv6 = if System.get_env("ECTO_IPV6"), do: [:inet6], else: []
 
+  # `keepalive: true` enables TCP keepalive probes so the kernel notices a
+  # silently-dropped connection (mirrors the Hammer.Redis fix in this same
+  # file) instead of the connection sitting half-open until DBConnection's
+  # periodic idle-check read times out, surfacing as `Postgrex.Protocol
+  # disconnected: ** (DBConnection.ConnectionError) ssl recv (idle):
+  # timeout`. Applies to both the legacy DO-managed Postgres and the
+  # in-cluster CNPG pooler.
+  socket_options = maybe_ipv6 ++ [keepalive: true]
+
   # TLS for Postgrex is built from the environment by Malan.RepoConfig (extracted
   # there so it is unit-testable; runtime.exs is not loaded by the test suite).
   # DATABASE_SSL_MODE selects verify_full (in-cluster CNPG pooler: chain +
@@ -359,10 +368,9 @@ if config_env() == :prod do
   database_ssl = RepoConfig.ssl_opts(System.get_env())
 
   config :malan, Malan.Repo,
-    # socket_options: [:inet6],
     url: database_url,
     pool_size: String.to_integer(System.get_env("POOL_SIZE") || "10"),
-    socket_options: maybe_ipv6,
+    socket_options: socket_options,
     ssl: database_ssl
 
   # The secret key base is used to sign/encrypt cookies and other secrets.

--- a/lib/malan/accounts.ex
+++ b/lib/malan/accounts.ex
@@ -2168,10 +2168,17 @@ defmodule Malan.Accounts do
         remote_ip,
         log_changeset
       ) do
+    # Log.create_changeset/2 casts this field via cast_embed, which requires a
+    # map (or nil). Anything else (e.g. a bare error atom like
+    # :too_many_requests passed by mistake instead of nil) fails Ecto's cast
+    # with "changeset: is invalid" and permanently fails the async
+    # LogWriter job after exhausting retries. Coerce to nil instead of
+    # letting a non-map value reach the embed. See MALAN-ED.
     serializable_changeset =
       case log_changeset do
         %Ecto.Changeset{} -> Log.Changes.map_from_changeset(log_changeset)
-        other -> other
+        other when is_map(other) -> other
+        _other -> nil
       end
 
     %{

--- a/lib/malan/accounts/log.ex
+++ b/lib/malan/accounts/log.ex
@@ -105,7 +105,9 @@ defmodule Malan.Accounts.Log do
 
   defp_testable truncate_field(changeset, field) do
     case get_change(changeset, field) do
-      str when is_binary(str) -> put_change(changeset, field, Utils.trunc_str(str, 255))
+      str when is_binary(str) ->
+        truncated = str |> String.codepoints() |> Enum.take(255) |> Enum.join()
+        put_change(changeset, field, truncated)
       _ -> changeset
     end
   end

--- a/lib/malan/accounts/log.ex
+++ b/lib/malan/accounts/log.ex
@@ -75,6 +75,7 @@ defmodule Malan.Accounts.Log do
       :remote_ip
     ])
     |> cast_embed(:changeset, with: &Log.Changes.changeset/2)
+    |> truncate_long_fields()
     |> put_default_when()
     |> validate_required([:success, :type, :verb, :when, :what, :remote_ip])
     |> validate_type()
@@ -85,6 +86,28 @@ defmodule Malan.Accounts.Log do
     |> foreign_key_constraint(:user_id)
     |> foreign_key_constraint(:session_id)
     |> foreign_key_constraint(:who)
+  end
+
+  # `:what` and `:who_username` are varchar(255) with no length validation,
+  # so a caller building `:what` from `Utils.Ecto.Changeset.errors_to_str/1`
+  # (which joins every error on a changeset into one string) can produce a
+  # value long enough that Postgres itself rejects the raw INSERT with
+  # `Postgrex.Error` 22001 ("string data right truncation") - a hard crash
+  # instead of a normal validation failure, permanently failing the async
+  # LogWriter job after exhausting retries. Truncate defensively rather than
+  # reject: losing the tail of a human-readable description is preferable to
+  # losing the entire audit row. See MALAN-EG.
+  defp_testable truncate_long_fields(changeset) do
+    changeset
+    |> truncate_field(:what)
+    |> truncate_field(:who_username)
+  end
+
+  defp_testable truncate_field(changeset, field) do
+    case get_change(changeset, field) do
+      str when is_binary(str) -> put_change(changeset, field, Utils.trunc_str(str, 255))
+      _ -> changeset
+    end
   end
 
   defp_testable put_default_when(changeset) do

--- a/lib/malan_web/controllers/user_controller.ex
+++ b/lib/malan_web/controllers/user_controller.ex
@@ -417,8 +417,11 @@ defmodule MalanWeb.UserController do
           |> put_view(ErrorJSON)
           |> render(:"500")
 
-          {:error, :too_many_requests}
-
+        {:error, :too_many_requests} ->
+          # log_changeset is nil here (not the :too_many_requests atom) because
+          # Log.create_changeset/2 casts this field via cast_embed, which requires
+          # a map (or nil) - passing a bare atom fails Ecto's cast with "is invalid"
+          # and permanently fails the async LogWriter job. See MALAN-ED.
           record_log_password_reset_email_fail(
             conn,
             user,
@@ -428,6 +431,7 @@ defmodule MalanWeb.UserController do
 
           conn
           |> put_view(ErrorJSON)
+          |> put_status(:too_many_requests)
           |> render(:"429")
 
         {:error, err_cs} ->


### PR DESCRIPTION
- Fix POST /api/users/:id/reset_password passing the bare atom :too_many_requests as the audit-log changeset when the per-user rate limit trips; it was falling through to a generic error clause instead of a dedicated one (dead/unreachable code removed in the process). The atom got JSON-stringified and failed cast_embed, permanently failing the async LogWriter job after 10 retries. Also hardened Accounts.record_log/10 to coerce any non-map changeset to nil so this class of bug can't recur from another call site. (MALAN-ED, ~708 events/mo)
- Add TCP keepalive (socket_options: [keepalive: true]) to Malan.Repo, mirroring the existing Redis fix, so the kernel notices a silently-dropped Postgres connection instead of it going half-open until DBConnection's idle-check read times out. (MALAN-DP and the wider SSL-idle-timeout cluster, ~471 events/mo)
- Truncate Log.what/Log.who_username to 255 chars before insert instead of letting an over-length value (e.g. a :what built from Utils.Ecto.Changeset.errors_to_str/1 joining several validation errors) hit Postgres raw and raise 22001 — trading the tail of a description for keeping the whole audit row. (MALAN-EG, ~130 events/mo)